### PR TITLE
MIDI レイヤー切替 / MUTE-SOLO / Config モーダル / UX 改善 (v1.1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,6 +64,12 @@
             <button id="midi-learn-btn" class="text-[10px] bg-slate-900 hover:bg-slate-800 text-slate-500 px-3 py-1.5 rounded font-bold transition-colors border border-slate-700" title="MIDI Learn: click then move a slider, then turn a MIDI knob">
                 LEARN
             </button>
+            <button id="midi-config-btn" class="text-[10px] bg-slate-900 hover:bg-slate-800 text-slate-400 px-2 py-1.5 rounded font-bold transition-colors border border-slate-700" title="MIDI Configuration">
+                &#9881;
+            </button>
+            <button id="blackout-btn" class="text-[10px] bg-slate-900 hover:bg-slate-800 text-slate-500 px-3 py-1.5 rounded font-bold transition-colors border border-slate-700" title="Blackout output (B)">
+                BLACKOUT
+            </button>
             <button id="debug-toggle-btn" class="text-[10px] bg-slate-900 hover:bg-slate-800 text-slate-300 px-3 py-1.5 rounded font-bold transition-colors border border-slate-700">
                 DEBUG
             </button>
@@ -168,6 +174,7 @@
             <div class="flex-1 relative flex items-center justify-center bg-[#050505] overflow-hidden group">
                 <div class="absolute inset-0 opacity-20 pointer-events-none" style="background-image: radial-gradient(#1e293b 1px, transparent 1px); background-size: 40px 40px;"></div>
                 <canvas id="main-canvas" class="shadow-2xl shadow-black max-w-full max-h-full object-contain"></canvas>
+                <div id="blackout-label" class="hidden absolute top-3 left-1/2 -translate-x-1/2 px-3 py-1 rounded bg-red-900/70 border border-red-500 text-red-200 text-[10px] font-bold tracking-widest pointer-events-none">● BLACKOUT</div>
             </div>
 
             <!-- Layer Stack -->
@@ -229,6 +236,149 @@
         </div>
     </div>
 
+    <!-- MIDI Configuration Modal -->
+    <div id="midi-modal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/90 backdrop-blur-md hidden opacity-0 transition-opacity duration-200">
+        <div class="bg-slate-900 border border-slate-700 rounded-xl shadow-2xl w-full max-w-5xl h-[85vh] flex flex-col transform scale-95 transition-transform duration-200 modal-content overflow-hidden">
+            <div class="p-5 border-b border-slate-700 flex justify-between items-center bg-slate-950">
+                <div class="flex items-center gap-4">
+                    <h2 class="text-xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-300 to-cyan-300">MIDI Configuration</h2>
+                    <div id="midi-monitor-indicator" class="flex items-center gap-2 text-[10px] text-slate-500 font-mono">
+                        <span id="midi-activity-dot" class="w-1.5 h-1.5 rounded-full bg-slate-700 transition-colors"></span>
+                        <span id="midi-activity-text">idle</span>
+                    </div>
+                </div>
+                <button id="midi-modal-close" class="text-slate-500 hover:text-white text-2xl leading-none transition-colors">&times;</button>
+            </div>
+            <div class="flex border-b border-slate-700 bg-slate-950">
+                <button class="midi-tab px-4 py-3 text-[11px] font-bold tracking-wider text-slate-400 hover:text-white border-b-2 border-transparent data-[active=true]:text-purple-300 data-[active=true]:border-purple-400" data-tab="mappings" data-active="true">MAPPINGS</button>
+                <button class="midi-tab px-4 py-3 text-[11px] font-bold tracking-wider text-slate-400 hover:text-white border-b-2 border-transparent data-[active=true]:text-purple-300 data-[active=true]:border-purple-400" data-tab="devices" data-active="false">DEVICES</button>
+                <button class="midi-tab px-4 py-3 text-[11px] font-bold tracking-wider text-slate-400 hover:text-white border-b-2 border-transparent data-[active=true]:text-purple-300 data-[active=true]:border-purple-400" data-tab="clock" data-active="false">CLOCK / SYNC</button>
+                <button class="midi-tab px-4 py-3 text-[11px] font-bold tracking-wider text-slate-400 hover:text-white border-b-2 border-transparent data-[active=true]:text-purple-300 data-[active=true]:border-purple-400" data-tab="actions" data-active="false">GLOBAL</button>
+            </div>
+            <div class="flex-1 overflow-y-auto p-5 bg-slate-900">
+                <!-- Mappings Tab -->
+                <section id="midi-tab-mappings" class="midi-tab-content">
+                    <div class="flex justify-between items-center mb-3">
+                        <div class="flex items-center gap-3">
+                            <span class="text-[11px] font-bold text-slate-300">Bindings</span>
+                            <select id="midi-mappings-filter" class="bg-slate-950 border border-slate-800 text-[10px] text-slate-400 rounded px-2 py-1">
+                                <option value="all">All</option>
+                                <option value="scene">Scene</option>
+                                <option value="layer">Layer</option>
+                                <option value="uniform">Uniform</option>
+                                <option value="global">Global</option>
+                            </select>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <button id="midi-add-mapping-btn" class="text-[10px] bg-purple-600 hover:bg-purple-500 text-white font-bold px-3 py-1.5 rounded transition-colors">+ ADD</button>
+                            <button id="midi-learn-any-btn" class="text-[10px] bg-slate-800 hover:bg-slate-700 text-slate-200 font-bold px-3 py-1.5 rounded transition-colors">LEARN → ADD</button>
+                        </div>
+                    </div>
+                    <table class="w-full text-[10px]">
+                        <thead class="sticky top-0 bg-slate-900 text-[9px] text-slate-500 uppercase tracking-wider">
+                            <tr class="border-b border-slate-800">
+                                <th class="text-left py-2 px-2">MIDI</th>
+                                <th class="text-left py-2 px-2">Action</th>
+                                <th class="text-left py-2 px-2">Target</th>
+                                <th class="text-left py-2 px-2">Behavior</th>
+                                <th class="text-left py-2 px-2">Label</th>
+                                <th class="w-20"></th>
+                            </tr>
+                        </thead>
+                        <tbody id="midi-mappings-body" class="text-slate-300"></tbody>
+                    </table>
+                    <div id="midi-mappings-empty" class="hidden py-12 text-center text-[11px] text-slate-500">
+                        No bindings yet. Press <kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">+ ADD</kbd> or <kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">LEARN → ADD</kbd>.
+                    </div>
+                </section>
+                <!-- Devices Tab -->
+                <section id="midi-tab-devices" class="midi-tab-content hidden">
+                    <div class="flex items-center justify-between mb-3">
+                        <span class="text-[11px] font-bold text-slate-300">Input Devices</span>
+                        <span class="text-[9px] text-slate-500">Disabled devices are ignored by this app.</span>
+                    </div>
+                    <div id="midi-devices-list" class="space-y-2"></div>
+                    <div class="mt-6">
+                        <div class="text-[10px] font-bold text-slate-400 mb-2 tracking-wider">LIVE MONITOR</div>
+                        <div id="midi-monitor-log" class="h-32 bg-slate-950 border border-slate-800 rounded p-2 text-[10px] font-mono text-slate-500 overflow-y-auto"></div>
+                    </div>
+                </section>
+                <!-- Clock Tab -->
+                <section id="midi-tab-clock" class="midi-tab-content hidden">
+                    <div class="space-y-4 max-w-xl">
+                        <label class="flex items-center gap-3 text-[11px] text-slate-300">
+                            <input id="midi-clock-enable" type="checkbox" class="accent-cyan-500">
+                            <span>Receive MIDI Clock (sync BPM from external source)</span>
+                        </label>
+                        <label class="flex items-center gap-3 text-[11px] text-slate-300 ml-6">
+                            <input id="midi-clock-ignore-transport" type="checkbox" class="accent-cyan-500">
+                            <span>Ignore Start/Stop (keep beat running regardless)</span>
+                        </label>
+                        <div class="mt-2 p-3 bg-slate-950 border border-slate-800 rounded text-[11px] font-mono space-y-1 text-slate-400">
+                            <div>Source: <span id="midi-clock-source">Manual</span></div>
+                            <div>Detected BPM: <span id="midi-clock-bpm">--</span></div>
+                            <div>Transport: <span id="midi-clock-transport">stopped</span></div>
+                        </div>
+                        <p class="text-[10px] text-slate-500 mt-1">MIDI Clock uses 24 pulses per quarter note. When enabled, the manual BPM field is disabled and tap tempo remains available but will be overridden on the next clock tick.</p>
+                    </div>
+                </section>
+                <!-- Global Actions Tab -->
+                <section id="midi-tab-actions" class="midi-tab-content hidden">
+                    <div class="space-y-3 max-w-xl">
+                        <button id="midi-panic-btn" class="w-full text-sm bg-red-900 hover:bg-red-800 border border-red-700 text-red-200 font-bold px-4 py-3 rounded">MIDI PANIC (release all held / clear solo / blackout)</button>
+                        <button id="midi-clear-bindings-btn" class="w-full text-xs bg-slate-800 hover:bg-slate-700 text-slate-200 font-bold px-4 py-2 rounded border border-slate-700">Clear All Bindings</button>
+                        <button id="midi-export-bindings-btn" class="w-full text-xs bg-slate-800 hover:bg-slate-700 text-slate-200 font-bold px-4 py-2 rounded border border-slate-700">Export Bindings (JSON)</button>
+                        <label class="w-full text-xs bg-slate-800 hover:bg-slate-700 text-slate-200 font-bold px-4 py-2 rounded border border-slate-700 cursor-pointer text-center block">
+                            Import Bindings (JSON)
+                            <input id="midi-import-bindings" type="file" accept=".json" class="hidden">
+                        </label>
+                        <div class="mt-6 text-[11px] text-slate-400 space-y-1">
+                            <div class="font-bold text-slate-300 mb-2">Shortcuts</div>
+                            <div><kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">1</kbd>-<kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">9</kbd> Recall scene 1..9</div>
+                            <div><kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">0</kbd> or <kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">B</kbd> Toggle blackout</div>
+                            <div><kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">Shift+B</kbd> MIDI Panic</div>
+                            <div><kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">T</kbd> Tap tempo</div>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </div>
+
+    <!-- Binding Editor Modal (inside Mappings table workflow) -->
+    <div id="midi-binding-editor" class="fixed inset-0 z-[60] flex items-center justify-center bg-black/90 backdrop-blur-sm hidden opacity-0 transition-opacity duration-200">
+        <div class="bg-slate-900 border border-slate-700 rounded-lg shadow-2xl w-[440px] max-w-[90vw] p-5 space-y-3 modal-content">
+            <h3 class="text-base font-bold text-white">Edit Binding</h3>
+            <div class="grid grid-cols-3 gap-2 items-center text-[11px]">
+                <label class="text-slate-400">MIDI Signature</label>
+                <div class="col-span-2 flex items-center gap-2">
+                    <span id="mbe-signature" class="flex-1 bg-slate-950 border border-slate-800 rounded px-2 py-1 font-mono text-slate-300">—</span>
+                    <button id="mbe-learn-btn" class="text-[10px] bg-purple-700 hover:bg-purple-600 text-white px-2 py-1 rounded">LEARN</button>
+                </div>
+
+                <label class="text-slate-400">Action</label>
+                <select id="mbe-action" class="col-span-2 bg-slate-950 border border-slate-800 rounded px-2 py-1 text-slate-200"></select>
+
+                <label class="text-slate-400">Target</label>
+                <div id="mbe-target-wrap" class="col-span-2 space-y-1"></div>
+
+                <label class="text-slate-400">Behavior</label>
+                <select id="mbe-behavior" class="col-span-2 bg-slate-950 border border-slate-800 rounded px-2 py-1 text-slate-200">
+                    <option value="trigger">Trigger (one-shot on press)</option>
+                    <option value="toggle">Toggle (flip state)</option>
+                    <option value="momentary">Momentary (hold)</option>
+                </select>
+
+                <label class="text-slate-400">Label</label>
+                <input id="mbe-label" type="text" placeholder="optional" class="col-span-2 bg-slate-950 border border-slate-800 rounded px-2 py-1 text-slate-200">
+            </div>
+            <div class="flex justify-end gap-2 pt-2">
+                <button id="mbe-cancel" class="text-[11px] px-3 py-1.5 rounded text-slate-300 hover:bg-slate-800">Cancel</button>
+                <button id="mbe-save" class="text-[11px] px-4 py-1.5 rounded bg-purple-600 hover:bg-purple-500 text-white font-bold">Save</button>
+            </div>
+        </div>
+    </div>
+
     <!-- Code Editor Modal -->
     <div id="code-modal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/95 backdrop-blur hidden opacity-0 transition-opacity">
         <div class="bg-[#1e1e1e] border border-slate-700 rounded-lg shadow-2xl w-full max-w-[90vw] h-[90vh] flex flex-col">
@@ -283,13 +433,17 @@
                     <span class="layer-name text-xs font-bold text-slate-200 select-none tracking-wide">Name</span>
                     <span class="layer-type text-[9px] px-1.5 py-0.5 rounded font-mono font-bold tracking-wider opacity-70">GEN</span>
                 </div>
-                <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                    <button class="layer-edit-btn p-1.5 text-slate-400 hover:text-blue-400 rounded hover:bg-slate-800 transition-colors" title="Edit Code">
-                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path></svg>
-                    </button>
-                    <button class="layer-del-btn p-1.5 text-slate-400 hover:text-red-400 rounded hover:bg-slate-800 transition-colors" title="Delete">
-                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
-                    </button>
+                <div class="flex items-center gap-1">
+                    <button class="layer-mute-btn w-6 h-6 text-[9px] font-bold rounded border border-slate-700 text-slate-500 hover:text-red-400 hover:border-red-500 transition-colors" title="Mute layer (M)">M</button>
+                    <button class="layer-solo-btn w-6 h-6 text-[9px] font-bold rounded border border-slate-700 text-slate-500 hover:text-yellow-300 hover:border-yellow-400 transition-colors" title="Solo layer (S)">S</button>
+                    <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+                        <button class="layer-edit-btn p-1.5 text-slate-400 hover:text-blue-400 rounded hover:bg-slate-800 transition-colors" title="Edit Code">
+                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path></svg>
+                        </button>
+                        <button class="layer-del-btn p-1.5 text-slate-400 hover:text-red-400 rounded hover:bg-slate-800 transition-colors" title="Delete">
+                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
+                        </button>
+                    </div>
                 </div>
             </div>
             

--- a/progress.md
+++ b/progress.md
@@ -13,3 +13,53 @@ Original prompt: レイヤー、シーン切り替え構造壊れてるかも
 - 検証: `npm run build` 成功。
 - 検証: Node 簡易検証で「crossfade 中に target scene を上書きしない」「空 scene finalize」「autosave 自己再入なし」「無効 load で crossfade を cancel しない」「不正 target の finalize でも現シーン保持」を確認。
 - メモ: Playwright クライアントは Node 側の ESM 実行回避までは通せたが、この Linux 環境で Chromium 実行に `libnspr4.so` など共有ライブラリが不足し、スクリーンショット検証までは未実行。
+
+---
+
+## v1.1 — MIDI 拡張 / レイヤー MUTE-SOLO / UX 改善 (2026-04-22)
+
+Original prompt (follow-up): "VJ ツールとしての改善を多く行ってほしい。レイヤーの切り替えを MIDI で行えるようにしたい。MIDI コンフィグの項目を追加すべき。"
+
+### MIDI エンジン拡張 (`src/midi/`)
+- `midi-manager.js` を Note On/Off・Program Change・MIDI Clock (24 PPQN) 受信に対応。Clock は直近 24 パルスの移動平均から BPM を推定し、差分 0.1 BPM 以上で `midi:clock-tick` を発火する。
+- デバイス単位の enable/disable を実装 (`state.midi.devices`、`localStorage: vj_midi_devices`)。Config モーダルからトグルできる。
+- MIDI Panic を追加 (Learn キャンセル / momentary 解除 / solo 解除 / blackout 解除)。
+- `armLearnOnce()` で Config モーダル用の "次の1メッセージを取得" API を新設。
+- 活動モニタ: `midi:activity` イベントを発火し、ヘッダドット点滅と Config モニタに反映。
+- 新規: `midi-actions.js` (アクションカタログ) と `midi-bindings.js` (signature="type|ch|number" 形式のバインディング + dispatch)。
+- アクション: `scene.recall`, `scene.next`, `scene.prev`, `layer.mute`, `layer.solo`, `layer.select`, `layer.opacity`, `layer.blend.next`, `uniform.set`, `crossfade.mix`, `bpm.tap`, `app.blackout`, `app.panic`。
+- Note の挙動は `trigger` / `toggle` / `momentary` を選択可能。CC はエッジ閾値 (0.5) でボタン的挙動も扱う。
+- 既存 `state.midi.map` (CC→uniform) は legacy として保持し、migration なしで継続動作。
+
+### レイヤー MUTE/SOLO / アクティブ選択
+- `layer.muted` を追加。renderer は per-layer 描画は続けたまま合成時のみスキップするため、サムネイルや feedback buffer は動き続ける。
+- `state.soloLayerId` を追加。solo 中は他レイヤーを合成しない。
+- `state.blackout` を追加し、renderer は blackout 時に黒フレームを直接出力。
+- レイヤーカードに M / S ボタンと `.layer-muted` 視覚状態を追加。
+- カードクリックで active 選択 (`layer:select`)。
+
+### BPM Clock ソース
+- `BpmSync` が `midi:clock-tick` / `midi:clock-start` / `midi:clock-stop` / `bpm:tap` を受信。Clock 有効時は手動 BPM 入力を disable。
+
+### MIDI Config モーダル
+- ヘッダに `⚙` ボタンを追加。Mappings / Devices / Clock / Global Actions の 4 タブ構成。
+- Mappings: 表形式で一覧・フィルタ (Scene / Layer / Uniform / Global)・Learn → Add・手動編集モーダル。
+- Devices: 接続状態とデバイス enable/disable + LIVE MONITOR (直近 40 行の受信ログ)。
+- Clock: 受信 ON/OFF、Start/Stop 無視、推定 BPM と Transport 状態表示。
+- Global: MIDI Panic、全バインディング削除、JSON export/import、ショートカット表。
+
+### UX 改善
+- ヘッダに `BLACKOUT` ボタン + キャンバス上に赤ラベル。
+- ショートカット: `1..9` = シーン呼び出し、`0` / `B` = blackout、`Shift+B` = Panic、`T` = tap (既存)。
+- Escape: Learn キャンセル → Binding Editor → MIDI Config → 既存 modal の優先順で閉じる。
+
+### 永続化
+- プロジェクトスキーマを `1.1` に更新。`midi.bindings`, `midi.clock`, `layers[].muted`, `app.blackout` を保存対象に追加。
+- `project-migrator.js`: `0.5-alpha → 1.0 → 1.1` を連鎖適用。legacy `midi.map` は保持。
+- `restoreFromStorage()` は旧 localStorage キー `vj_project_autosave_v0_5` をフォールバック読み込みして v1.1 キーへ自動保存。
+
+### 検証
+- `npm run build` 成功。
+- Node 簡易テスト: signature 構築/解析/omni match、scene.recall on note、layer.mute toggle、momentary edge on/off、uniform.set on cc、PC → scene.recall fallback、actionSupports の境界をいずれも確認。
+- migrator: 0.5-alpha と 1.0 のプロジェクトがどちらも 1.1 に展開され、legacy midi.map は温存されることを確認。
+- メモ: ブラウザ UI / Web MIDI 実機テストはこの環境では未実施 (手動確認を次のステップで推奨)。

--- a/src/core/app-state.js
+++ b/src/core/app-state.js
@@ -19,10 +19,30 @@ export class AppState {
         this.preserveDrawingBuffer = localStorage.getItem('vj_preserve_buffer') === '1';
 
         // --- MIDI ---
+        // map: legacy CC→uniform map, kept for backwards compatibility.
+        //      Format: { "layerId::u_key": ccNumber }
+        //      On v1.1+ projects the canonical source is `bindings`.
+        // bindings: array of action-level bindings.
+        //      Shape: { id, signature, action: { type, target, behavior, invert }, label }
+        //      signature format: "cc|Ch|Num", "note|Ch|Num", "pc|Ch|Num" (Ch=1-16 or 0 for omni).
+        // devices: per-device enabled flag (keyed by device id).
+        // clock:   MIDI Clock sync state.
+        // activity: last-received signature + timestamp (for UI pulse).
         this.midi = {
             inputs: [],
             map: {},
-            learn: { active: false, targetMapKey: null }
+            bindings: [],
+            devices: {},
+            clock: {
+                enabled: false,
+                ignoreTransport: false,
+                running: false,
+                lastPulseMs: 0,
+                pulseIntervals: [],
+                estimatedBpm: 0
+            },
+            activity: { signature: null, at: 0 },
+            learn: { active: false, targetMapKey: null, targetBindingId: null }
         };
 
         // --- BPM / Sync ---
@@ -60,8 +80,17 @@ export class AppState {
         this.webcam = null;
         this.webcamStream = null;
 
+        // --- App-level live controls ---
+        // blackout: when true, renderer outputs black (post-crossfade overlay).
+        // soloLayerId: if set, only that layer is composited (others suppressed).
+        //              null means solo inactive.
+        this.blackout = false;
+        this.soloLayerId = null;
+
         // --- Persistence ---
-        this.projectStorageKey = 'vj_project_autosave_v0_5';
+        // Storage key is versioned; v1.1 adds bindings/clock/blackout etc.
+        this.projectStorageKey = 'vj_project_autosave_v1_1';
+        this.legacyStorageKeys = ['vj_project_autosave_v0_5'];
         this.storageErrorShown = false;
 
         // --- Debug ---

--- a/src/layer/layer-manager.js
+++ b/src/layer/layer-manager.js
@@ -4,11 +4,26 @@
  * Each layer has a ShaderMaterial, RenderTarget, uniform definitions,
  * and optional feedback buffer (FBO).
  *
+ * Live flags on a layer:
+ *   muted:  boolean — compositor skips this layer when true
+ *   active: boolean — UI selection (only one layer is active at a time)
+ *
  * Events emitted:
  *   project:autosave  (queued after changes)
- *   toast              { msg, type }
+ *   toast             { msg, type }
+ *   layer:select      { layerId, source } (when UI selects a layer)
+ *
+ * Events consumed:
+ *   layer:mute       { layerId, value, source }
+ *   layer:solo       { layerId, source }  (null = clear solo)
+ *   layer:select     { layerId, source }
+ *   layer:opacity    { layerId, value }
+ *   layer:blend-step { layerId, delta }
+ *   uniform:set      { layerId, uKey, norm }
  */
 const THREE = window.THREE;
+
+const BLEND_NAMES = ['NORMAL','ADD','MULTIPLY','SCREEN','DIFFERENCE','OVERLAY','SOFT_LIGHT','HARD_LIGHT','COLOR_DODGE','COLOR_BURN'];
 
 export class LayerManager {
     /**
@@ -22,6 +37,17 @@ export class LayerManager {
         this._renderer = deps.renderer;
         this._midiManager = deps.midiManager;
 
+        this._bindEvents();
+    }
+
+    _bindEvents() {
+        const bus = this._bus;
+        bus.on('layer:mute', ({ layerId, value }) => this.setMute(layerId, value));
+        bus.on('layer:solo', ({ layerId }) => this.toggleSolo(layerId));
+        bus.on('layer:select', ({ layerId }) => this.selectLayer(layerId));
+        bus.on('layer:opacity', ({ layerId, value }) => this.setOpacity(layerId, value));
+        bus.on('layer:blend-step', ({ layerId, delta }) => this.stepBlend(layerId, delta));
+        bus.on('uniform:set', ({ layerId, uKey, norm }) => this.setUniformNorm(layerId, uKey, norm));
     }
 
     generateLayerId() {
@@ -54,74 +80,7 @@ export class LayerManager {
         return { ...fallback, ...primary };
     }
 
-    /**
-     * Add a layer from a shader key and optional saved config.
-     * @param {string} key
-     * @param {Object|null} config
-     * @returns {Object|null} layer
-     */
-    addLayer(key, config = null, options = {}) {
-        const def = window.SHADERS[key];
-        if (!def) {
-            this._bus.emit('toast', { msg: `Unknown shader key: ${key}`, type: 'error' });
-            return null;
-        }
-        if (def.isWebCam) this._renderer.initWebCam();
-
-        const s = this._state;
-        const uniformDefs = this.sanitizeUniformsDef(
-            config && config.uniformsDef ? config.uniformsDef : def.uniforms,
-            def.uniforms
-        );
-
-        const id = (config && typeof config.id === 'string' && config.id) ? config.id : this.generateLayerId();
-        const blendRaw = config ? Number(config.blend) : 0;
-        const opacityRaw = config ? Number(config.opacity) : 1.0;
-
-        const layer = {
-            id, key, name: def.name,
-            blend: Number.isFinite(blendRaw) ? Math.max(0, Math.min(9, Math.round(blendRaw))) : 0,
-            opacity: Number.isFinite(opacityRaw) ? Math.max(0, Math.min(1, opacityRaw)) : 1.0,
-            needsInput: def.needsInput, isFeedback: def.isFeedback, isWebCam: def.isWebCam,
-            fragmentShader: (config && typeof config.fragmentShader === 'string') ? config.fragmentShader : def.fragmentShader,
-            uniformsDef: uniformDefs,
-            uniforms: {
-                u_time: { value: 0 },
-                u_resolution: { value: new THREE.Vector2(s.width, s.height) },
-                u_bass: { value: 0 }, u_mid: { value: 0 }, u_treble: { value: 0 },
-                u_bpm: { value: s.bpm }, u_beat: { value: 0 }, u_phase: { value: 0 },
-                u_inputTexture: { value: null }, u_webcamTexture: { value: null }, u_prevLayer: { value: null }
-            },
-            renderTarget: this._renderer.createRenderTarget(),
-            fbo: def.isFeedback ? this._renderer.createRenderTarget() : null
-        };
-
-        // Init uniform values
-        Object.keys(uniformDefs).forEach(k => {
-            let val;
-            if (config && config.uniformValues && config.uniformValues[k] !== undefined) {
-                const configVal = Number(config.uniformValues[k]);
-                const min = uniformDefs[k].min;
-                const max = uniformDefs[k].max;
-                val = Number.isFinite(configVal) ? Math.min(max, Math.max(min, configVal)) : uniformDefs[k].value;
-            } else {
-                val = uniformDefs[k].value;
-            }
-            layer.uniforms[k] = { value: val };
-        });
-
-        layer.material = this._renderer.createLayerMaterial(layer.uniforms, layer.fragmentShader);
-        s.layers.push(layer);
-        this.renderLayerUI(layer);
-        if (!options.skipSave) this.queueSceneSave();
-        return layer;
-    }
-
-    /**
-     * Build a layer object without adding to state.layers or rendering UI.
-     * Used for crossfade scene B layers.
-     */
-    buildLayerNoUI(key, config = null) {
+    _createLayerBase(key, config) {
         const def = window.SHADERS[key];
         if (!def) return null;
         if (def.isWebCam) this._renderer.initWebCam();
@@ -140,6 +99,8 @@ export class LayerManager {
             id, key, name: def.name,
             blend: Number.isFinite(blendRaw) ? Math.max(0, Math.min(9, Math.round(blendRaw))) : 0,
             opacity: Number.isFinite(opacityRaw) ? Math.max(0, Math.min(1, opacityRaw)) : 1.0,
+            muted: !!(config && config.muted),
+            active: false,
             needsInput: def.needsInput, isFeedback: def.isFeedback, isWebCam: def.isWebCam,
             fragmentShader: (config && typeof config.fragmentShader === 'string') ? config.fragmentShader : def.fragmentShader,
             uniformsDef: uniformDefs,
@@ -173,11 +134,30 @@ export class LayerManager {
         return layer;
     }
 
+    addLayer(key, config = null, options = {}) {
+        const def = window.SHADERS[key];
+        if (!def) {
+            this._bus.emit('toast', { msg: `Unknown shader key: ${key}`, type: 'error' });
+            return null;
+        }
+        const layer = this._createLayerBase(key, config);
+        if (!layer) return null;
+        this._state.layers.push(layer);
+        this.renderLayerUI(layer);
+        if (!options.skipSave) this.queueSceneSave();
+        return layer;
+    }
+
+    buildLayerNoUI(key, config = null) {
+        return this._createLayerBase(key, config);
+    }
+
     removeLayer(layer, el = null) {
         const s = this._state;
         s.layers = s.layers.filter(l => l !== layer);
         if (el) el.remove();
         this._midiManager.cleanupMidiForLayer(layer);
+        if (s.soloLayerId === layer.id) s.soloLayerId = null;
         layer.material.dispose();
         layer.renderTarget.dispose();
         if (layer.fbo) layer.fbo.dispose();
@@ -188,6 +168,96 @@ export class LayerManager {
         this._bus.emit('project:autosave');
     }
 
+    // ---------- Live state setters ----------
+
+    setMute(layerId, value) {
+        const layer = this._state.layers.find(l => l.id === layerId);
+        if (!layer) return;
+        layer.muted = !!value;
+        this._refreshLayerCardState(layer);
+        this.queueSceneSave();
+    }
+
+    toggleSolo(layerId) {
+        const s = this._state;
+        // null → clear solo
+        if (layerId == null) {
+            s.soloLayerId = null;
+            this._refreshAllCards();
+            return;
+        }
+        s.soloLayerId = s.soloLayerId === layerId ? null : layerId;
+        this._refreshAllCards();
+    }
+
+    selectLayer(layerId) {
+        const s = this._state;
+        s.layers.forEach(l => { l.active = (l.id === layerId); });
+        this._refreshAllCards();
+    }
+
+    setOpacity(layerId, norm) {
+        const layer = this._state.layers.find(l => l.id === layerId);
+        if (!layer) return;
+        layer.opacity = Math.max(0, Math.min(1, norm));
+        const card = this._findCard(layerId);
+        if (card) {
+            const slider = card.querySelector('.layer-opacity');
+            const v = card.querySelector('.layer-opacity-val');
+            if (slider) slider.value = layer.opacity;
+            if (v) v.textContent = layer.opacity.toFixed(2);
+        }
+        this.queueSceneSave();
+    }
+
+    stepBlend(layerId, delta) {
+        const layer = this._state.layers.find(l => l.id === layerId);
+        if (!layer) return;
+        layer.blend = (((layer.blend + delta) % BLEND_NAMES.length) + BLEND_NAMES.length) % BLEND_NAMES.length;
+        const card = this._findCard(layerId);
+        if (card) {
+            const blend = card.querySelector('.layer-blend');
+            if (blend) blend.value = BLEND_NAMES[layer.blend];
+        }
+        this.queueSceneSave();
+    }
+
+    setUniformNorm(layerId, uKey, norm) {
+        const layer = this._state.layers.find(l => l.id === layerId);
+        if (!layer || !layer.uniformsDef[uKey] || !layer.uniforms[uKey]) return;
+        const def = layer.uniformsDef[uKey];
+        const v = def.min + norm * (def.max - def.min);
+        layer.uniforms[uKey].value = v;
+        const slider = document.getElementById(`slider-${layer.id}::${uKey}`);
+        if (slider) {
+            slider.value = v;
+            const valDisplay = slider.previousElementSibling && slider.previousElementSibling.lastElementChild;
+            if (valDisplay) valDisplay.textContent = v.toFixed(2);
+        }
+        this.queueSceneSave();
+    }
+
+    _findCard(layerId) {
+        return document.querySelector(`.layer-card[data-id="${layerId}"]`);
+    }
+
+    _refreshLayerCardState(layer) {
+        const card = this._findCard(layer.id);
+        if (!card) return;
+        card.classList.toggle('layer-muted', !!layer.muted);
+        const muteBtn = card.querySelector('.layer-mute-btn');
+        if (muteBtn) muteBtn.classList.toggle('layer-flag-on', !!layer.muted);
+        const soloBtn = card.querySelector('.layer-solo-btn');
+        if (soloBtn) soloBtn.classList.toggle('layer-flag-on', this._state.soloLayerId === layer.id);
+        card.classList.toggle('active', !!layer.active);
+    }
+
+    _refreshAllCards() {
+        this._state.layers.forEach(l => this._refreshLayerCardState(l));
+    }
+
+    // ---------- UI rendering ----------
+
     renderLayerUI(layer, options = {}) {
         const tpl = document.getElementById('layer-ui-template');
         const el = tpl.content.cloneNode(true).firstElementChild;
@@ -195,6 +265,31 @@ export class LayerManager {
         el.querySelector('.layer-name').textContent = layer.name;
         el.querySelector('.layer-type').textContent = layer.needsInput ? 'FX' : 'GEN';
         el.querySelector('.layer-type').className = `text-[9px] px-1.5 py-0.5 rounded font-mono font-bold tracking-wider ${layer.needsInput ? 'bg-indigo-900 text-indigo-300' : 'bg-emerald-900 text-emerald-300'}`;
+
+        // Click to select active layer
+        el.addEventListener('click', (e) => {
+            // Avoid swallowing interactive children
+            if (e.target.closest('input, button, select, .control-slider')) return;
+            this._bus.emit('layer:select', { layerId: layer.id, source: 'ui' });
+        });
+
+        // Mute / Solo buttons
+        const muteBtn = el.querySelector('.layer-mute-btn');
+        const soloBtn = el.querySelector('.layer-solo-btn');
+        if (muteBtn) {
+            muteBtn.classList.toggle('layer-flag-on', !!layer.muted);
+            muteBtn.onclick = (e) => {
+                e.stopPropagation();
+                this._bus.emit('layer:mute', { layerId: layer.id, value: !layer.muted, source: 'ui' });
+            };
+        }
+        if (soloBtn) {
+            soloBtn.classList.toggle('layer-flag-on', this._state.soloLayerId === layer.id);
+            soloBtn.onclick = (e) => {
+                e.stopPropagation();
+                this._bus.emit('layer:solo', { layerId: layer.id, source: 'ui' });
+            };
+        }
 
         // Opacity
         const op = el.querySelector('.layer-opacity');
@@ -209,18 +304,21 @@ export class LayerManager {
 
         // Blend
         const blend = el.querySelector('.layer-blend');
-        const blends = { 'NORMAL': 0, 'ADD': 1, 'MULTIPLY': 2, 'SCREEN': 3, 'DIFFERENCE': 4, 'OVERLAY': 5, 'SOFT_LIGHT': 6, 'HARD_LIGHT': 7, 'COLOR_DODGE': 8, 'COLOR_BURN': 9 };
-        Object.keys(blends).forEach(k => { if (blends[k] === layer.blend) blend.value = k; });
+        BLEND_NAMES.forEach((k, i) => { if (i === layer.blend) blend.value = k; });
         blend.onchange = (e) => {
-            layer.blend = blends[e.target.value];
+            layer.blend = BLEND_NAMES.indexOf(e.target.value);
             this.queueSceneSave();
         };
 
         // Remove
-        el.querySelector('.layer-del-btn').onclick = () => this.removeLayer(layer, el);
+        el.querySelector('.layer-del-btn').onclick = (e) => {
+            e.stopPropagation();
+            this.removeLayer(layer, el);
+        };
 
         // Code edit
-        el.querySelector('.layer-edit-btn').onclick = () => {
+        el.querySelector('.layer-edit-btn').onclick = (e) => {
+            e.stopPropagation();
             this._bus.emit('editor:open', { layer });
         };
 
@@ -242,7 +340,7 @@ export class LayerManager {
             valDisplay.className = 'text-[9px] text-slate-400';
             valDisplay.textContent = layer.uniforms[uKey].value.toFixed(2);
 
-            // MIDI CC input
+            // MIDI CC input (legacy map — still supported)
             const cc = document.createElement('input');
             cc.type = 'number';
             cc.placeholder = 'CC';
@@ -286,6 +384,7 @@ export class LayerManager {
                 this._state.midi.map[mapKey] = v;
                 this.queueSceneSave();
             };
+            cc.onclick = (e) => e.stopPropagation();
 
             head.append(label, cc, valDisplay);
 
@@ -313,6 +412,10 @@ export class LayerManager {
             wrap.append(head, slider);
             cont.appendChild(wrap);
         });
+
+        // Initial state classes
+        el.classList.toggle('layer-muted', !!layer.muted);
+        el.classList.toggle('active', !!layer.active);
 
         const stack = document.getElementById('layer-stack');
         if (options.replaceEl && options.replaceEl.parentElement === stack) {

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,8 @@ import { AudioAnalyzer } from './audio/audio-analyzer.js';
 import { Renderer } from './renderer/renderer.js';
 import { BpmSync } from './sync/bpm-sync.js';
 import { MidiManager } from './midi/midi-manager.js';
+import { MidiBindings } from './midi/midi-bindings.js';
+import { MidiConfigUI } from './midi/midi-config-ui.js';
 import { LayerManager } from './layer/layer-manager.js';
 import { SceneManager } from './scene/scene-manager.js';
 import { EditorController } from './editor/editor-controller.js';
@@ -53,6 +55,8 @@ function boot() {
 
     // ── 3. Modules with cross-module deps ────────────────────
     const midiManager = new MidiManager(bus, state);
+    const midiBindings = new MidiBindings(bus, state);
+    midiManager.setBindings(midiBindings);
 
     const layerManager = new LayerManager(bus, state, {
         renderer,
@@ -81,6 +85,11 @@ function boot() {
         undoManager
     });
 
+    const midiConfigUI = new MidiConfigUI(bus, state, {
+        midiManager,
+        bindings: midiBindings
+    });
+
     const uiController = new UIController(bus, state, {
         renderer,
         layerManager,
@@ -89,6 +98,7 @@ function boot() {
         bpmSync,
         projectIO,
         midiManager,
+        midiConfigUI,
         audio
     });
 
@@ -99,11 +109,33 @@ function boot() {
     debugPanel.installGlobalErrorHooks();
     sceneManager.initUI();
     projectIO.initImportUI();
+    midiConfigUI.initUI();
     uiController.initUI();
 
     // ── 5. Init MIDI (audio is user-triggered via MIC/SYS buttons) ──
+    midiManager._loadDevicePrefs();
     midiManager.init();
     midiManager.initLearnUI();
+
+    // ── 5b. App-level live-state listeners ───────────────────
+    bus.on('app:blackout', ({ active }) => {
+        state.blackout = !!active;
+        const label = document.getElementById('blackout-label');
+        const btn = document.getElementById('blackout-btn');
+        if (label) label.classList.toggle('hidden', !state.blackout);
+        if (btn) {
+            btn.classList.toggle('bg-red-900', !!state.blackout);
+            btn.classList.toggle('text-red-200', !!state.blackout);
+            btn.classList.toggle('border-red-600', !!state.blackout);
+            btn.classList.toggle('text-slate-500', !state.blackout);
+            btn.classList.toggle('border-slate-700', !state.blackout);
+        }
+    });
+    bus.on('app:panic', () => midiManager.panic());
+    bus.on('crossfade:mix', ({ mix }) => {
+        // Direct crossfade mix override from a MIDI fader — only meaningful while a crossfade is active.
+        if (state.crossfade.active) state.crossfade.mix = Math.max(0, Math.min(1, mix));
+    });
 
     // ── 6. Restore project or create default scene ───────────
     if (!projectIO.restoreFromStorage()) {

--- a/src/midi/midi-actions.js
+++ b/src/midi/midi-actions.js
@@ -1,0 +1,129 @@
+/**
+ * MIDI Action catalog.
+ *
+ * Each action type declares:
+ *   - label: human-readable name
+ *   - category: grouping for the Config UI
+ *   - supports: which message types can trigger it (cc/note/pc)
+ *   - continuous: true for CC-style value mapping (0..1 → target range)
+ *   - target: shape hint for the target picker
+ *     'none' | 'sceneIdx' | 'layerRef' | 'layerRef.uniform' | 'cue'
+ *   - defaultBehavior (note only): 'trigger' | 'toggle' | 'momentary'
+ */
+export const MIDI_ACTIONS = {
+    'scene.recall': {
+        label: 'Recall Scene',
+        category: 'Scene',
+        supports: ['note', 'cc', 'pc'],
+        continuous: false,
+        target: 'sceneIdx',
+        defaultBehavior: 'trigger'
+    },
+    'scene.next': {
+        label: 'Next Scene',
+        category: 'Scene',
+        supports: ['note', 'cc'],
+        continuous: false,
+        target: 'none',
+        defaultBehavior: 'trigger'
+    },
+    'scene.prev': {
+        label: 'Prev Scene',
+        category: 'Scene',
+        supports: ['note', 'cc'],
+        continuous: false,
+        target: 'none',
+        defaultBehavior: 'trigger'
+    },
+    'layer.mute': {
+        label: 'Toggle Layer MUTE',
+        category: 'Layer',
+        supports: ['note', 'cc'],
+        continuous: false,
+        target: 'layerRef',
+        defaultBehavior: 'toggle'
+    },
+    'layer.solo': {
+        label: 'Toggle Layer SOLO',
+        category: 'Layer',
+        supports: ['note', 'cc'],
+        continuous: false,
+        target: 'layerRef',
+        defaultBehavior: 'toggle'
+    },
+    'layer.select': {
+        label: 'Select Active Layer',
+        category: 'Layer',
+        supports: ['note', 'cc'],
+        continuous: false,
+        target: 'layerRef',
+        defaultBehavior: 'trigger'
+    },
+    'layer.opacity': {
+        label: 'Layer Opacity',
+        category: 'Layer',
+        supports: ['cc'],
+        continuous: true,
+        target: 'layerRef',
+        defaultBehavior: null
+    },
+    'layer.blend.next': {
+        label: 'Next Blend Mode',
+        category: 'Layer',
+        supports: ['note', 'cc'],
+        continuous: false,
+        target: 'layerRef',
+        defaultBehavior: 'trigger'
+    },
+    'uniform.set': {
+        label: 'Uniform (continuous)',
+        category: 'Uniform',
+        supports: ['cc'],
+        continuous: true,
+        target: 'layerRef.uniform',
+        defaultBehavior: null
+    },
+    'crossfade.mix': {
+        label: 'Crossfade Mix (fader)',
+        category: 'Global',
+        supports: ['cc'],
+        continuous: true,
+        target: 'none',
+        defaultBehavior: null
+    },
+    'bpm.tap': {
+        label: 'Tap Tempo',
+        category: 'Global',
+        supports: ['note', 'cc'],
+        continuous: false,
+        target: 'none',
+        defaultBehavior: 'trigger'
+    },
+    'app.blackout': {
+        label: 'Blackout Toggle',
+        category: 'Global',
+        supports: ['note', 'cc'],
+        continuous: false,
+        target: 'none',
+        defaultBehavior: 'toggle'
+    },
+    'app.panic': {
+        label: 'MIDI Panic',
+        category: 'Global',
+        supports: ['note', 'cc'],
+        continuous: false,
+        target: 'none',
+        defaultBehavior: 'trigger'
+    }
+};
+
+export function getActionMeta(type) {
+    return MIDI_ACTIONS[type] || null;
+}
+
+/** All supported message types for a given action. */
+export function actionSupports(type, msgType) {
+    const meta = MIDI_ACTIONS[type];
+    if (!meta) return false;
+    return meta.supports.includes(msgType);
+}

--- a/src/midi/midi-bindings.js
+++ b/src/midi/midi-bindings.js
@@ -1,0 +1,304 @@
+/**
+ * MidiBindings — data layer + dispatcher for MIDI action bindings.
+ *
+ * Bindings are stored in state.midi.bindings (plain array).
+ * Each binding:
+ *   {
+ *     id:        'B_abc123',
+ *     signature: 'cc|1|74' | 'note|1|36' | 'pc|1|5',
+ *     action: {
+ *       type: 'scene.recall' | 'layer.mute' | ...,
+ *       target: { sceneIdx?, layerId?, layerIdx?, uKey? },
+ *       behavior: 'trigger'|'toggle'|'momentary' | null (cc),
+ *       invert:   boolean
+ *     },
+ *     label?: string
+ *   }
+ *
+ * Events emitted (via EventBus):
+ *   scene:recall    { index }
+ *   scene:step      { delta }            (+1 / -1)
+ *   layer:mute      { layerId, value, source }
+ *   layer:solo      { layerId, source }
+ *   layer:select    { layerId, source }
+ *   layer:opacity   { layerId, value, source }
+ *   layer:blend-step{ layerId, delta }
+ *   uniform:set     { layerId, uKey, norm, source }
+ *   crossfade:mix   { mix }              (manual override)
+ *   bpm:tap         {}
+ *   app:blackout    { active }
+ *   app:panic       {}
+ *   project:autosave (when state changes via dispatch)
+ */
+
+export const SIGNATURE_CHANNEL_OMNI = 0;
+
+export function buildSignature(type, channel, number) {
+    const ch = Number.isFinite(channel) && channel >= 1 && channel <= 16 ? channel : SIGNATURE_CHANNEL_OMNI;
+    return `${type}|${ch}|${number}`;
+}
+
+export function parseSignature(sig) {
+    if (typeof sig !== 'string') return null;
+    const parts = sig.split('|');
+    if (parts.length !== 3) return null;
+    const [type, chStr, numStr] = parts;
+    if (!['cc', 'note', 'pc'].includes(type)) return null;
+    const channel = parseInt(chStr, 10);
+    const number = parseInt(numStr, 10);
+    if (!Number.isFinite(channel) || !Number.isFinite(number)) return null;
+    return { type, channel, number };
+}
+
+export function formatSignature(sig) {
+    const p = parseSignature(sig);
+    if (!p) return sig;
+    const ch = p.channel === SIGNATURE_CHANNEL_OMNI ? 'omni' : `Ch${p.channel}`;
+    const label = p.type === 'cc' ? `CC${p.number}`
+        : p.type === 'note' ? `Note ${noteName(p.number)}`
+        : `PC${p.number}`;
+    return `${label} (${ch})`;
+}
+
+function noteName(n) {
+    const names = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+    const octave = Math.floor(n / 12) - 1;
+    return `${names[n % 12]}${octave}`;
+}
+
+/** Signature matches if channel is equal OR either side is omni. */
+function matchesSignature(storedSig, incoming) {
+    const parsed = parseSignature(storedSig);
+    if (!parsed) return false;
+    if (parsed.type !== incoming.type) return false;
+    if (parsed.number !== incoming.number) return false;
+    if (parsed.channel === SIGNATURE_CHANNEL_OMNI) return true;
+    if (incoming.channel === SIGNATURE_CHANNEL_OMNI) return true;
+    return parsed.channel === incoming.channel;
+}
+
+export class MidiBindings {
+    /**
+     * @param {import('../core/event-bus.js').EventBus} bus
+     * @param {import('../core/app-state.js').AppState} state
+     */
+    constructor(bus, state) {
+        this._bus = bus;
+        this._state = state;
+        this._bindingIdCounter = 0;
+        // Track momentary note-held layer states for auto-release
+        // { bindingId: prevValue }
+        this._momentaryHeld = {};
+    }
+
+    generateBindingId() {
+        const n = this._bindingIdCounter++;
+        const rand = Math.random().toString(36).slice(2, 6);
+        return `B_${Date.now().toString(36)}_${n.toString(36)}_${rand}`;
+    }
+
+    /** Add or replace a binding. Returns the binding. */
+    upsert(binding) {
+        if (!binding || !binding.signature || !binding.action) return null;
+        if (!binding.id) binding.id = this.generateBindingId();
+        const list = this._state.midi.bindings;
+        const idx = list.findIndex(b => b.id === binding.id);
+        if (idx >= 0) list[idx] = binding;
+        else list.push(binding);
+        return binding;
+    }
+
+    remove(id) {
+        const s = this._state;
+        s.midi.bindings = s.midi.bindings.filter(b => b.id !== id);
+    }
+
+    removeForLayer(layerId) {
+        const s = this._state;
+        s.midi.bindings = s.midi.bindings.filter(b => {
+            const t = b.action && b.action.target;
+            if (!t) return true;
+            return t.layerId !== layerId;
+        });
+    }
+
+    findBySignature(incoming) {
+        return this._state.midi.bindings.filter(b => matchesSignature(b.signature, incoming));
+    }
+
+    /**
+     * Resolve a layer reference in binding target.
+     * Returns the live layer object or null.
+     */
+    resolveLayer(target) {
+        if (!target) return null;
+        const s = this._state;
+        if (target.layerId) {
+            const l = s.layers.find(x => x.id === target.layerId);
+            if (l) return l;
+        }
+        if (Number.isFinite(target.layerIdx)) {
+            const l = s.layers[target.layerIdx];
+            if (l) return l;
+        }
+        return null;
+    }
+
+    /**
+     * Dispatch an incoming MIDI message to all matching bindings.
+     * @param {Object} incoming - { type, channel, number, raw, norm, on }
+     *   norm: 0..1 (cc value or velocity)
+     *   on:   boolean (note on / off)
+     */
+    dispatch(incoming) {
+        const matches = this.findBySignature(incoming);
+        if (matches.length === 0) return false;
+        let anyChanged = false;
+        matches.forEach(b => {
+            if (this._runBinding(b, incoming)) anyChanged = true;
+        });
+        if (anyChanged) this._bus.emit('project:autosave');
+        return matches.length > 0;
+    }
+
+    _runBinding(binding, incoming) {
+        const action = binding.action;
+        if (!action) return false;
+        const t = action.type;
+        const target = action.target || {};
+        const behavior = action.behavior || 'trigger';
+
+        // Resolve trigger / continuous semantics by incoming type:
+        //   CC  → continuous (norm 0..1). For action.toggle use mid-threshold.
+        //   Note→ on/off edge triggered
+        //   PC  → always trigger on receive
+
+        // Invert flips norm
+        const norm = action.invert ? (1 - incoming.norm) : incoming.norm;
+
+        // Edge: did we just go "on"?
+        let edgeOn = false;
+        let edgeOff = false;
+        if (incoming.type === 'note') {
+            edgeOn = !!incoming.on;
+            edgeOff = !incoming.on;
+        } else if (incoming.type === 'pc') {
+            edgeOn = true;
+        } else {
+            // cc: treat >= 64 as on, < 64 as off for button-like actions
+            const prevKey = `${binding.id}:last`;
+            const prev = this._momentaryHeld[prevKey] || 0;
+            if (norm >= 0.5 && prev < 0.5) edgeOn = true;
+            if (norm < 0.5 && prev >= 0.5) edgeOff = true;
+            this._momentaryHeld[prevKey] = norm;
+        }
+
+        switch (t) {
+            case 'scene.recall': {
+                if (!edgeOn) return false;
+                const idx = Number.isFinite(target.sceneIdx) ? target.sceneIdx
+                    : (incoming.type === 'pc' ? incoming.number : null);
+                if (idx == null) return false;
+                this._bus.emit('scene:recall', { index: idx });
+                return true;
+            }
+            case 'scene.next':
+                if (edgeOn) { this._bus.emit('scene:step', { delta: 1 }); return true; }
+                return false;
+            case 'scene.prev':
+                if (edgeOn) { this._bus.emit('scene:step', { delta: -1 }); return true; }
+                return false;
+            case 'layer.mute': {
+                const layer = this.resolveLayer(target);
+                if (!layer) return false;
+                if (behavior === 'momentary') {
+                    if (edgeOn) {
+                        this._momentaryHeld[binding.id] = layer.muted === true;
+                        this._bus.emit('layer:mute', { layerId: layer.id, value: true, source: 'midi' });
+                        return true;
+                    } else if (edgeOff) {
+                        const restore = this._momentaryHeld[binding.id];
+                        this._bus.emit('layer:mute', { layerId: layer.id, value: !!restore, source: 'midi' });
+                        delete this._momentaryHeld[binding.id];
+                        return true;
+                    }
+                    return false;
+                }
+                // Toggle / Trigger: flip on edgeOn
+                if (edgeOn) {
+                    this._bus.emit('layer:mute', { layerId: layer.id, value: !layer.muted, source: 'midi' });
+                    return true;
+                }
+                return false;
+            }
+            case 'layer.solo': {
+                const layer = this.resolveLayer(target);
+                if (!layer) return false;
+                if (edgeOn) {
+                    this._bus.emit('layer:solo', { layerId: layer.id, source: 'midi' });
+                    return true;
+                }
+                return false;
+            }
+            case 'layer.select': {
+                const layer = this.resolveLayer(target);
+                if (!layer) return false;
+                if (edgeOn) {
+                    this._bus.emit('layer:select', { layerId: layer.id, source: 'midi' });
+                    return true;
+                }
+                return false;
+            }
+            case 'layer.opacity': {
+                const layer = this.resolveLayer(target);
+                if (!layer) return false;
+                this._bus.emit('layer:opacity', { layerId: layer.id, value: norm, source: 'midi' });
+                return true;
+            }
+            case 'layer.blend.next': {
+                const layer = this.resolveLayer(target);
+                if (!layer) return false;
+                if (edgeOn) {
+                    this._bus.emit('layer:blend-step', { layerId: layer.id, delta: 1 });
+                    return true;
+                }
+                return false;
+            }
+            case 'uniform.set': {
+                const layer = this.resolveLayer(target);
+                if (!layer || !target.uKey) return false;
+                this._bus.emit('uniform:set', { layerId: layer.id, uKey: target.uKey, norm, source: 'midi' });
+                return true;
+            }
+            case 'crossfade.mix': {
+                this._bus.emit('crossfade:mix', { mix: norm });
+                return true;
+            }
+            case 'bpm.tap':
+                if (edgeOn) { this._bus.emit('bpm:tap', {}); return true; }
+                return false;
+            case 'app.blackout': {
+                if (behavior === 'momentary') {
+                    if (edgeOn) { this._bus.emit('app:blackout', { active: true, source: 'midi' }); return true; }
+                    if (edgeOff) { this._bus.emit('app:blackout', { active: false, source: 'midi' }); return true; }
+                    return false;
+                }
+                if (edgeOn) {
+                    this._bus.emit('app:blackout', { active: !this._state.blackout, source: 'midi' });
+                    return true;
+                }
+                return false;
+            }
+            case 'app.panic':
+                if (edgeOn) { this._bus.emit('app:panic', {}); return true; }
+                return false;
+            default:
+                return false;
+        }
+    }
+
+    /** Release any held momentary bindings (used by Panic). */
+    releaseAllMomentary() {
+        this._momentaryHeld = {};
+    }
+}

--- a/src/midi/midi-config-ui.js
+++ b/src/midi/midi-config-ui.js
@@ -1,0 +1,520 @@
+/**
+ * MidiConfigUI — binds DOM for the MIDI Configuration modal.
+ *
+ * Tabs: Mappings, Devices, Clock/Sync, Global Actions.
+ */
+import { MIDI_ACTIONS, getActionMeta, actionSupports } from './midi-actions.js';
+import { buildSignature, parseSignature, formatSignature, SIGNATURE_CHANNEL_OMNI } from './midi-bindings.js';
+
+const MONITOR_MAX_LINES = 40;
+
+export class MidiConfigUI {
+    /**
+     * @param {import('../core/event-bus.js').EventBus} bus
+     * @param {import('../core/app-state.js').AppState} state
+     * @param {Object} deps - { midiManager, bindings }
+     */
+    constructor(bus, state, deps) {
+        this._bus = bus;
+        this._state = state;
+        this._midiManager = deps.midiManager;
+        this._bindings = deps.bindings;
+
+        this._monitorLines = [];
+        this._activePulseTimer = null;
+        this._editor = null; // current editor state { binding, isNew }
+    }
+
+    initUI() {
+        const open = () => this.open();
+        const cfgBtn = document.getElementById('midi-config-btn');
+        if (cfgBtn) cfgBtn.onclick = open;
+
+        document.getElementById('midi-modal-close').onclick = () => this.close();
+
+        document.querySelectorAll('.midi-tab').forEach(tab => {
+            tab.onclick = () => this._setTab(tab.dataset.tab);
+        });
+
+        // Mappings tab actions
+        document.getElementById('midi-add-mapping-btn').onclick = () => this._openEditor(null, { manualSignature: true });
+        document.getElementById('midi-learn-any-btn').onclick = () => this._addByLearn();
+        document.getElementById('midi-mappings-filter').onchange = () => this._renderMappings();
+
+        // Binding editor modal
+        document.getElementById('mbe-cancel').onclick = () => this._closeEditor();
+        document.getElementById('mbe-save').onclick = () => this._saveEditor();
+        document.getElementById('mbe-learn-btn').onclick = () => this._editorLearn();
+        document.getElementById('mbe-action').onchange = () => this._refreshEditorTarget();
+
+        // Populate action <select>
+        const actionSel = document.getElementById('mbe-action');
+        actionSel.innerHTML = '';
+        Object.keys(MIDI_ACTIONS).forEach(k => {
+            const meta = MIDI_ACTIONS[k];
+            const opt = document.createElement('option');
+            opt.value = k;
+            opt.textContent = `[${meta.category}] ${meta.label}`;
+            actionSel.appendChild(opt);
+        });
+
+        // Devices
+        this._bus.on('midi:devices-changed', () => this._renderDevices());
+
+        // Clock tab
+        const clockEnable = document.getElementById('midi-clock-enable');
+        const clockIgnore = document.getElementById('midi-clock-ignore-transport');
+        clockEnable.onchange = (e) => {
+            this._state.midi.clock.enabled = !!e.target.checked;
+            this._bus.emit('project:autosave');
+            this._renderClockStatus();
+        };
+        clockIgnore.onchange = (e) => {
+            this._state.midi.clock.ignoreTransport = !!e.target.checked;
+            this._bus.emit('project:autosave');
+        };
+        this._bus.on('midi:clock-tick', () => this._renderClockStatus());
+        this._bus.on('midi:clock-start', () => this._renderClockStatus());
+        this._bus.on('midi:clock-stop', () => this._renderClockStatus());
+
+        // Global tab
+        document.getElementById('midi-panic-btn').onclick = () => this._midiManager.panic();
+        document.getElementById('midi-clear-bindings-btn').onclick = () => {
+            if (!confirm('Clear ALL bindings? This cannot be undone.')) return;
+            this._state.midi.bindings = [];
+            this._bus.emit('project:autosave');
+            this._renderMappings();
+        };
+        document.getElementById('midi-export-bindings-btn').onclick = () => this._exportBindings();
+        document.getElementById('midi-import-bindings').onchange = (e) => this._importBindings(e);
+
+        // Activity monitor
+        this._bus.on('midi:activity', (data) => this._onActivity(data));
+    }
+
+    open() {
+        const m = document.getElementById('midi-modal');
+        m.classList.remove('hidden');
+        setTimeout(() => m.classList.remove('opacity-0'), 10);
+        this._setTab('mappings');
+        this._renderMappings();
+        this._renderDevices();
+        this._renderClockStatus();
+        document.getElementById('midi-clock-enable').checked = !!this._state.midi.clock.enabled;
+        document.getElementById('midi-clock-ignore-transport').checked = !!this._state.midi.clock.ignoreTransport;
+    }
+
+    close() {
+        const m = document.getElementById('midi-modal');
+        m.classList.add('opacity-0');
+        setTimeout(() => m.classList.add('hidden'), 200);
+    }
+
+    isOpen() {
+        const m = document.getElementById('midi-modal');
+        return m && !m.classList.contains('hidden');
+    }
+
+    _setTab(name) {
+        document.querySelectorAll('.midi-tab').forEach(t => {
+            t.dataset.active = (t.dataset.tab === name) ? 'true' : 'false';
+        });
+        ['mappings', 'devices', 'clock', 'actions'].forEach(t => {
+            const el = document.getElementById(`midi-tab-${t}`);
+            if (!el) return;
+            el.classList.toggle('hidden', t !== name);
+        });
+    }
+
+    // ---------- Mappings tab ----------
+
+    _renderMappings() {
+        const body = document.getElementById('midi-mappings-body');
+        const empty = document.getElementById('midi-mappings-empty');
+        const filter = document.getElementById('midi-mappings-filter').value;
+        body.innerHTML = '';
+
+        const bindings = this._state.midi.bindings.filter(b => {
+            if (filter === 'all') return true;
+            const meta = getActionMeta(b.action.type);
+            if (!meta) return false;
+            const cat = meta.category.toLowerCase();
+            return cat === filter;
+        });
+
+        if (bindings.length === 0) {
+            empty.classList.remove('hidden');
+            return;
+        }
+        empty.classList.add('hidden');
+
+        bindings.forEach(b => {
+            const tr = document.createElement('tr');
+            tr.className = 'border-b border-slate-800 hover:bg-slate-800/40';
+
+            const sig = document.createElement('td');
+            sig.className = 'py-1.5 px-2 font-mono text-purple-300';
+            sig.textContent = formatSignature(b.signature);
+
+            const meta = getActionMeta(b.action.type);
+            const action = document.createElement('td');
+            action.className = 'py-1.5 px-2';
+            action.textContent = meta ? meta.label : b.action.type;
+
+            const target = document.createElement('td');
+            target.className = 'py-1.5 px-2 text-slate-400';
+            target.textContent = this._describeTarget(b);
+
+            const beh = document.createElement('td');
+            beh.className = 'py-1.5 px-2 text-slate-500';
+            beh.textContent = b.action.behavior || '—';
+
+            const label = document.createElement('td');
+            label.className = 'py-1.5 px-2 text-slate-400';
+            label.textContent = b.label || '';
+
+            const actions = document.createElement('td');
+            actions.className = 'py-1.5 px-2 text-right';
+            const editBtn = document.createElement('button');
+            editBtn.textContent = 'Edit';
+            editBtn.className = 'text-[10px] text-slate-400 hover:text-white mr-2';
+            editBtn.onclick = () => this._openEditor(b);
+            const delBtn = document.createElement('button');
+            delBtn.textContent = 'Del';
+            delBtn.className = 'text-[10px] text-slate-500 hover:text-red-400';
+            delBtn.onclick = () => {
+                this._bindings.remove(b.id);
+                this._bus.emit('project:autosave');
+                this._renderMappings();
+            };
+            actions.append(editBtn, delBtn);
+
+            tr.append(sig, action, target, beh, label, actions);
+            body.appendChild(tr);
+        });
+    }
+
+    _describeTarget(b) {
+        const t = b.action.target || {};
+        if (Number.isFinite(t.sceneIdx)) {
+            const scene = this._state.scenes[t.sceneIdx];
+            return `Scene ${t.sceneIdx + 1}${scene ? ` — ${scene.name}` : ''}`;
+        }
+        if (t.layerId) {
+            const layer = this._state.layers.find(l => l.id === t.layerId);
+            const name = layer ? layer.name : '(unknown)';
+            return t.uKey ? `${name} / ${t.uKey.replace('u_', '')}` : name;
+        }
+        if (Number.isFinite(t.layerIdx)) {
+            return `Layer #${t.layerIdx + 1}`;
+        }
+        return '—';
+    }
+
+    _openEditor(binding, opts = {}) {
+        const isNew = !binding;
+        const draft = binding
+            ? JSON.parse(JSON.stringify(binding))
+            : {
+                id: null,
+                signature: opts.signature || null,
+                action: { type: 'scene.recall', target: { sceneIdx: 0 }, behavior: 'trigger', invert: false },
+                label: ''
+            };
+        this._editor = { draft, isNew };
+
+        document.getElementById('mbe-signature').textContent = draft.signature ? formatSignature(draft.signature) : '—';
+        document.getElementById('mbe-action').value = draft.action.type;
+        document.getElementById('mbe-behavior').value = draft.action.behavior || 'trigger';
+        document.getElementById('mbe-label').value = draft.label || '';
+        this._refreshEditorTarget();
+
+        const m = document.getElementById('midi-binding-editor');
+        m.classList.remove('hidden');
+        setTimeout(() => m.classList.remove('opacity-0'), 10);
+    }
+
+    _closeEditor() {
+        this._editor = null;
+        const m = document.getElementById('midi-binding-editor');
+        m.classList.add('opacity-0');
+        setTimeout(() => m.classList.add('hidden'), 150);
+    }
+
+    _refreshEditorTarget() {
+        if (!this._editor) return;
+        const type = document.getElementById('mbe-action').value;
+        const meta = getActionMeta(type);
+        const wrap = document.getElementById('mbe-target-wrap');
+        wrap.innerHTML = '';
+        // Migrate target when switching action
+        const draft = this._editor.draft;
+        draft.action.type = type;
+        if (!draft.action.target) draft.action.target = {};
+
+        // Behavior defaults
+        const behSel = document.getElementById('mbe-behavior');
+        if (meta && meta.defaultBehavior && !draft.action.behavior) {
+            behSel.value = meta.defaultBehavior;
+            draft.action.behavior = meta.defaultBehavior;
+        }
+        behSel.disabled = !!(meta && meta.continuous);
+
+        if (!meta || meta.target === 'none') {
+            const span = document.createElement('span');
+            span.className = 'text-slate-500 text-[10px]';
+            span.textContent = 'No target needed';
+            wrap.appendChild(span);
+            return;
+        }
+
+        if (meta.target === 'sceneIdx') {
+            const sel = document.createElement('select');
+            sel.className = 'bg-slate-950 border border-slate-800 rounded px-2 py-1 text-slate-200 w-full text-[11px]';
+            this._state.scenes.forEach((sc, i) => {
+                const opt = document.createElement('option');
+                opt.value = String(i);
+                opt.textContent = `${i + 1}. ${sc.name}`;
+                sel.appendChild(opt);
+            });
+            if (Number.isFinite(draft.action.target.sceneIdx)) {
+                sel.value = String(draft.action.target.sceneIdx);
+            }
+            sel.onchange = () => { draft.action.target = { sceneIdx: parseInt(sel.value, 10) }; };
+            wrap.appendChild(sel);
+            return;
+        }
+
+        if (meta.target === 'layerRef' || meta.target === 'layerRef.uniform') {
+            const layerSel = document.createElement('select');
+            layerSel.className = 'bg-slate-950 border border-slate-800 rounded px-2 py-1 text-slate-200 w-full text-[11px]';
+            this._state.layers.forEach((l, i) => {
+                const opt = document.createElement('option');
+                opt.value = l.id;
+                opt.textContent = `${i + 1}. ${l.name}`;
+                layerSel.appendChild(opt);
+            });
+            if (this._state.layers.length === 0) {
+                const opt = document.createElement('option');
+                opt.value = '';
+                opt.textContent = '(no layers in current scene)';
+                layerSel.appendChild(opt);
+                layerSel.disabled = true;
+            }
+            if (draft.action.target.layerId) layerSel.value = draft.action.target.layerId;
+            layerSel.onchange = () => {
+                draft.action.target = { layerId: layerSel.value };
+                if (meta.target === 'layerRef.uniform') this._refreshEditorTarget();
+            };
+            wrap.appendChild(layerSel);
+
+            if (meta.target === 'layerRef.uniform') {
+                const uSel = document.createElement('select');
+                uSel.className = 'bg-slate-950 border border-slate-800 rounded px-2 py-1 text-slate-200 w-full text-[11px] mt-1';
+                const layer = this._state.layers.find(l => l.id === (draft.action.target.layerId || layerSel.value));
+                if (layer) {
+                    Object.keys(layer.uniformsDef).forEach(k => {
+                        const opt = document.createElement('option');
+                        opt.value = k;
+                        opt.textContent = k.replace('u_', '');
+                        uSel.appendChild(opt);
+                    });
+                }
+                if (draft.action.target.uKey) uSel.value = draft.action.target.uKey;
+                uSel.onchange = () => {
+                    draft.action.target.uKey = uSel.value;
+                };
+                // Ensure initial uKey is set
+                if (!draft.action.target.uKey && uSel.options.length > 0) {
+                    draft.action.target.uKey = uSel.value;
+                }
+                wrap.appendChild(uSel);
+            }
+            return;
+        }
+    }
+
+    async _editorLearn() {
+        const captured = await this._midiManager.armLearnOnce({ description: 'move/press the control for this binding' });
+        if (!captured) return;
+        if (!this._editor) return;
+        this._editor.draft.signature = captured.signature;
+        document.getElementById('mbe-signature').textContent = formatSignature(captured.signature);
+        // Auto-adjust: if message type doesn't support current action, pick first matching action
+        const type = captured.type;
+        const curAction = this._editor.draft.action.type;
+        if (!actionSupports(curAction, type)) {
+            const fallback = Object.keys(MIDI_ACTIONS).find(k => actionSupports(k, type));
+            if (fallback) {
+                this._editor.draft.action.type = fallback;
+                document.getElementById('mbe-action').value = fallback;
+                this._refreshEditorTarget();
+            }
+        }
+    }
+
+    _saveEditor() {
+        if (!this._editor) return;
+        const draft = this._editor.draft;
+        if (!draft.signature) {
+            alert('Assign a MIDI signature first (Learn or + Add by Learn).');
+            return;
+        }
+        const meta = getActionMeta(draft.action.type);
+        if (!meta) return;
+
+        const parsed = parseSignature(draft.signature);
+        if (!parsed || !actionSupports(draft.action.type, parsed.type)) {
+            alert(`Action "${meta.label}" does not support ${parsed ? parsed.type : 'this message type'}.`);
+            return;
+        }
+
+        draft.action.behavior = document.getElementById('mbe-behavior').value || 'trigger';
+        draft.label = document.getElementById('mbe-label').value || '';
+        draft.action.invert = !!draft.action.invert;
+
+        this._bindings.upsert(draft);
+        this._bus.emit('project:autosave');
+        this._renderMappings();
+        this._closeEditor();
+    }
+
+    async _addByLearn() {
+        const captured = await this._midiManager.armLearnOnce({ description: 'press the control to bind' });
+        if (!captured) return;
+        this._openEditor(null, { signature: captured.signature });
+        // Pre-pick action by captured type
+        const pref = Object.keys(MIDI_ACTIONS).find(k => actionSupports(k, captured.type));
+        if (pref) {
+            this._editor.draft.action.type = pref;
+            this._editor.draft.signature = captured.signature;
+            document.getElementById('mbe-signature').textContent = formatSignature(captured.signature);
+            document.getElementById('mbe-action').value = pref;
+            this._refreshEditorTarget();
+        }
+    }
+
+    // ---------- Devices tab ----------
+
+    _renderDevices() {
+        const list = document.getElementById('midi-devices-list');
+        if (!list) return;
+        list.innerHTML = '';
+        const devs = this._state.midi.devices || {};
+        const ids = Object.keys(devs);
+        if (ids.length === 0) {
+            const empty = document.createElement('div');
+            empty.className = 'text-[10px] text-slate-500 py-6 text-center';
+            empty.textContent = 'No MIDI devices detected. Connect a device and grant browser permission.';
+            list.appendChild(empty);
+            return;
+        }
+        ids.forEach(id => {
+            const d = devs[id];
+            const row = document.createElement('label');
+            row.className = 'flex items-center justify-between gap-3 bg-slate-950 border border-slate-800 rounded px-3 py-2 text-[11px]';
+            const info = document.createElement('div');
+            info.className = 'flex items-center gap-3 min-w-0';
+            const dot = document.createElement('span');
+            dot.className = `w-1.5 h-1.5 rounded-full ${d.connected ? 'bg-green-400' : 'bg-slate-600'}`;
+            const name = document.createElement('span');
+            name.className = 'text-slate-200 truncate';
+            name.textContent = d.name || id;
+            const idEl = document.createElement('span');
+            idEl.className = 'text-[9px] text-slate-500 font-mono truncate';
+            idEl.textContent = id;
+            info.append(dot, name, idEl);
+
+            const toggle = document.createElement('input');
+            toggle.type = 'checkbox';
+            toggle.checked = d.enabled !== false;
+            toggle.className = 'accent-cyan-500';
+            toggle.onchange = () => this._midiManager.setDeviceEnabled(id, toggle.checked);
+
+            row.append(info, toggle);
+            list.appendChild(row);
+        });
+    }
+
+    // ---------- Clock status ----------
+
+    _renderClockStatus() {
+        const c = this._state.midi.clock;
+        const src = document.getElementById('midi-clock-source');
+        const bpm = document.getElementById('midi-clock-bpm');
+        const tr = document.getElementById('midi-clock-transport');
+        if (src) src.textContent = c.enabled ? (c.running ? 'MIDI Clock (running)' : 'MIDI Clock (armed)') : 'Manual';
+        if (bpm) bpm.textContent = c.estimatedBpm ? c.estimatedBpm.toFixed(2) : '--';
+        if (tr) tr.textContent = c.running ? 'running' : 'stopped';
+    }
+
+    // ---------- Activity monitor ----------
+
+    _onActivity({ signature, type, number, channel, norm }) {
+        // Dot flash
+        const dot = document.getElementById('midi-activity-dot');
+        const text = document.getElementById('midi-activity-text');
+        const headerDot = document.getElementById('midi-status-dot');
+        if (dot) {
+            dot.classList.add('bg-purple-400');
+            dot.classList.remove('bg-slate-700');
+        }
+        if (headerDot) headerDot.classList.add('midi-pulse');
+        if (text) text.textContent = formatSignature(signature);
+        clearTimeout(this._activePulseTimer);
+        this._activePulseTimer = setTimeout(() => {
+            if (dot) { dot.classList.remove('bg-purple-400'); dot.classList.add('bg-slate-700'); }
+            if (headerDot) headerDot.classList.remove('midi-pulse');
+            if (text) text.textContent = 'idle';
+        }, 180);
+
+        // Monitor log
+        const log = document.getElementById('midi-monitor-log');
+        if (log && this.isOpen()) {
+            const line = document.createElement('div');
+            line.textContent = `${new Date().toISOString().slice(11, 19)} · ${formatSignature(signature)} · v=${norm.toFixed(3)}`;
+            log.appendChild(line);
+            this._monitorLines.push(line);
+            if (this._monitorLines.length > MONITOR_MAX_LINES) {
+                const removed = this._monitorLines.shift();
+                if (removed && removed.remove) removed.remove();
+            }
+            log.scrollTop = log.scrollHeight;
+        }
+    }
+
+    // ---------- Import / export ----------
+
+    _exportBindings() {
+        const payload = { version: '1.1', bindings: this._state.midi.bindings };
+        const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `vj_midi_bindings_${Date.now()}.json`;
+        a.click();
+        setTimeout(() => URL.revokeObjectURL(url), 1000);
+    }
+
+    _importBindings(e) {
+        const file = e.target.files && e.target.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = (ev) => {
+            try {
+                const data = JSON.parse(ev.target.result);
+                const incoming = Array.isArray(data) ? data : (Array.isArray(data.bindings) ? data.bindings : null);
+                if (!incoming) throw new Error('invalid format');
+                incoming.forEach(b => this._bindings.upsert(b));
+                this._bus.emit('project:autosave');
+                this._renderMappings();
+                this._bus.emit('toast', { msg: `Imported ${incoming.length} binding(s)`, type: 'success' });
+            } catch (err) {
+                this._bus.emit('toast', { msg: `Import failed: ${err.message || err}`, type: 'error' });
+            } finally {
+                e.target.value = '';
+            }
+        };
+        reader.readAsText(file);
+    }
+}

--- a/src/midi/midi-manager.js
+++ b/src/midi/midi-manager.js
@@ -1,28 +1,56 @@
 /**
- * MidiManager — WebMidi integration for CC mapping + MIDI Learn.
+ * MidiManager — WebMidi integration for VJ operation.
  *
- * Handles device connect/disconnect, CC message routing,
- * MIDI map normalization, conflict detection, and learn mode.
+ * Capabilities:
+ *   - CC, Note On/Off, Program Change receive
+ *   - MIDI Clock / Start / Stop receive (for BPM sync)
+ *   - Per-device enable/disable (id-based)
+ *   - MIDI Learn (captures next message → opens binding editor)
+ *   - Legacy CC→uniform map (state.midi.map) kept for back-compat
+ *   - MIDI Panic (clears held momentary, soloe, blackout)
+ *   - Activity emit (for UI pulse / monitor)
  *
  * Events emitted:
- *   midi:cc          { cc, norm }
- *   toast            { msg, type }
- *   project:autosave (queued after CC changes slider / mapping)
- *   debug:error      { message, source }
- *
- * Events consumed:
- *   (none — driven by WebMidi callbacks + DOM events)
+ *   midi:cc              { cc, norm, channel }          (legacy + live)
+ *   midi:note            { number, on, velocity, channel }
+ *   midi:pc              { number, channel }
+ *   midi:activity        { signature, type, number, channel, norm }
+ *   midi:devices-changed { devices }
+ *   midi:clock-tick      { bpm }                        (on estimated clock BPM update)
+ *   midi:clock-start     {}
+ *   midi:clock-stop      {}
+ *   midi:learned         { binding }                    (when Learn completes to a binding)
+ *   toast                { msg, type }
+ *   project:autosave
+ *   debug:error          { message, source }
  */
+
+import {
+    buildSignature,
+    parseSignature,
+    formatSignature,
+    SIGNATURE_CHANNEL_OMNI
+} from './midi-bindings.js';
+
+const CLOCK_PPQN = 24; // MIDI Clock pulses per quarter note
+
 export class MidiManager {
     /**
      * @param {import('../core/event-bus.js').EventBus} bus
      * @param {import('../core/app-state.js').AppState} state
+     * @param {Object} deps - { bindings: MidiBindings }
      */
-    constructor(bus, state) {
+    constructor(bus, state, deps = {}) {
         this._bus = bus;
         this._state = state;
+        this._bindings = deps.bindings || null;
+
         this._learnHighlightEl = null;
+        this._learnResolver = null;   // Promise resolver for learn-next-message
     }
+
+    /** Wire MidiBindings (set from main.js after construction). */
+    setBindings(bindings) { this._bindings = bindings; }
 
     /** Initialize WebMidi and bind inputs. */
     init() {
@@ -52,9 +80,67 @@ export class MidiManager {
     }
 
     _bindInputs() {
-        WebMidi.inputs.forEach(i => i.removeListener('controlchange'));
-        WebMidi.inputs.forEach(i => i.addListener('controlchange', (e) => this._handleCC(e)));
-        this._updateStatus(WebMidi.inputs.length > 0);
+        const listeners = ['controlchange', 'noteon', 'noteoff', 'programchange', 'clock', 'start', 'stop', 'continue'];
+        WebMidi.inputs.forEach(i => {
+            // Seed device record
+            const rec = this._state.midi.devices[i.id] || { name: i.name, enabled: true };
+            rec.name = i.name;
+            rec.connected = true;
+            this._state.midi.devices[i.id] = rec;
+            listeners.forEach(ev => i.removeListener(ev));
+            if (rec.enabled) {
+                i.addListener('controlchange', (e) => this._handleCC(e));
+                i.addListener('noteon', (e) => this._handleNote(e, true));
+                i.addListener('noteoff', (e) => this._handleNote(e, false));
+                i.addListener('programchange', (e) => this._handlePC(e));
+                i.addListener('clock', () => this._handleClock());
+                i.addListener('start', () => this._handleTransport('start'));
+                i.addListener('stop', () => this._handleTransport('stop'));
+                i.addListener('continue', () => this._handleTransport('continue'));
+            }
+        });
+        // Mark disconnected devices
+        Object.keys(this._state.midi.devices).forEach(id => {
+            const present = WebMidi.inputs.some(i => i.id === id);
+            if (!present) this._state.midi.devices[id].connected = false;
+        });
+        this._persistDevicePrefs();
+        this._updateStatus(WebMidi.inputs.some(i => (this._state.midi.devices[i.id] || {}).enabled !== false));
+        this._bus.emit('midi:devices-changed', { devices: this._state.midi.devices });
+    }
+
+    setDeviceEnabled(id, enabled) {
+        const rec = this._state.midi.devices[id];
+        if (!rec) return;
+        rec.enabled = !!enabled;
+        this._persistDevicePrefs();
+        this._bindInputs();
+    }
+
+    _persistDevicePrefs() {
+        try {
+            const compact = {};
+            Object.keys(this._state.midi.devices).forEach(id => {
+                const d = this._state.midi.devices[id];
+                compact[id] = { enabled: d.enabled !== false };
+            });
+            localStorage.setItem('vj_midi_devices', JSON.stringify(compact));
+        } catch (e) { /* ignore quota */ }
+    }
+
+    _loadDevicePrefs() {
+        try {
+            const raw = localStorage.getItem('vj_midi_devices');
+            if (!raw) return;
+            const data = JSON.parse(raw);
+            if (data && typeof data === 'object') {
+                Object.keys(data).forEach(id => {
+                    const rec = this._state.midi.devices[id] || { name: id, enabled: data[id].enabled !== false };
+                    rec.enabled = data[id].enabled !== false;
+                    this._state.midi.devices[id] = rec;
+                });
+            }
+        } catch (e) { /* ignore */ }
     }
 
     _updateStatus(active) {
@@ -69,21 +155,119 @@ export class MidiManager {
         }
     }
 
+    _pulseActivity(signature, payload) {
+        this._state.midi.activity = { signature, at: performance.now() };
+        this._bus.emit('midi:activity', { signature, ...payload });
+    }
+
+    // ---------- Incoming message handlers ----------
+
     _handleCC(e) {
         const cc = e.controller.number;
+        const channel = e.message ? e.message.channel : e.channel;
         const norm = this.normalizeMidiValue(e.value);
+        const signature = buildSignature('cc', channel, cc);
 
-        // Emit raw CC
-        this._bus.emit('midi:cc', { cc, norm });
+        this._pulseActivity(signature, { type: 'cc', number: cc, channel, norm });
+        this._bus.emit('midi:cc', { cc, norm, channel, signature });
 
-        // MIDI Learn: if active and we have a target, capture this CC
-        const learn = this._state.midi.learn;
-        if (learn.active && learn.targetMapKey) {
-            this._completeMidiLearn(cc);
+        // If Learn is active, capture + resolve
+        if (this._state.midi.learn.active) {
+            this._completeLearn({ type: 'cc', number: cc, channel, signature });
             return;
         }
 
-        // Route to mapped uniforms
+        // New binding system
+        let handled = false;
+        if (this._bindings) {
+            handled = this._bindings.dispatch({ type: 'cc', channel, number: cc, norm, on: norm >= 0.5 });
+        }
+
+        // Legacy uniform map: still honored so existing projects keep working
+        this._applyLegacyCCMap(cc, norm);
+    }
+
+    _handleNote(e, on) {
+        const number = e.note ? e.note.number : e.data && e.data[1];
+        if (!Number.isFinite(number)) return;
+        const channel = e.message ? e.message.channel : e.channel;
+        const velocity = on ? this.normalizeMidiValue(e.note && e.note.attack !== undefined ? e.note.attack : (e.velocity || 1)) : 0;
+        const signature = buildSignature('note', channel, number);
+
+        this._pulseActivity(signature, { type: 'note', number, channel, norm: velocity });
+        this._bus.emit('midi:note', { number, on, velocity, channel, signature });
+
+        if (this._state.midi.learn.active && on) {
+            this._completeLearn({ type: 'note', number, channel, signature });
+            return;
+        }
+
+        if (this._bindings) {
+            this._bindings.dispatch({ type: 'note', channel, number, norm: velocity, on });
+        }
+    }
+
+    _handlePC(e) {
+        const number = e.value !== undefined ? e.value : (e.number !== undefined ? e.number : (e.data && e.data[1]));
+        if (!Number.isFinite(number)) return;
+        const channel = e.message ? e.message.channel : e.channel;
+        const signature = buildSignature('pc', channel, number);
+
+        this._pulseActivity(signature, { type: 'pc', number, channel, norm: 1 });
+        this._bus.emit('midi:pc', { number, channel, signature });
+
+        if (this._state.midi.learn.active) {
+            this._completeLearn({ type: 'pc', number, channel, signature });
+            return;
+        }
+
+        if (this._bindings) {
+            this._bindings.dispatch({ type: 'pc', channel, number, norm: 1, on: true });
+        }
+    }
+
+    _handleClock() {
+        const s = this._state;
+        if (!s.midi.clock.enabled) return;
+        const now = performance.now();
+        const c = s.midi.clock;
+        if (c.lastPulseMs > 0) {
+            const dt = now - c.lastPulseMs;
+            if (dt > 0 && dt < 200) { // ignore obvious outliers
+                c.pulseIntervals.push(dt);
+                if (c.pulseIntervals.length > CLOCK_PPQN * 2) c.pulseIntervals.shift();
+            }
+        }
+        c.lastPulseMs = now;
+
+        // Estimate BPM from the last quarter-note worth of pulses
+        if (c.pulseIntervals.length >= CLOCK_PPQN) {
+            const recent = c.pulseIntervals.slice(-CLOCK_PPQN);
+            const avg = recent.reduce((a, b) => a + b, 0) / recent.length;
+            const bpm = 60000 / (avg * CLOCK_PPQN);
+            if (Number.isFinite(bpm) && bpm >= 40 && bpm <= 300) {
+                // Only emit if BPM shifted by >= 0.1
+                if (Math.abs((c.estimatedBpm || 0) - bpm) >= 0.1) {
+                    c.estimatedBpm = bpm;
+                    this._bus.emit('midi:clock-tick', { bpm });
+                }
+            }
+        }
+    }
+
+    _handleTransport(kind) {
+        const s = this._state;
+        if (!s.midi.clock.enabled || s.midi.clock.ignoreTransport) return;
+        s.midi.clock.running = kind !== 'stop';
+        s.midi.clock.pulseIntervals = [];
+        s.midi.clock.lastPulseMs = 0;
+        if (kind === 'start') this._bus.emit('midi:clock-start', {});
+        else if (kind === 'stop') this._bus.emit('midi:clock-stop', {});
+    }
+
+    // ---------- Legacy CC map (state.midi.map) ----------
+
+    _applyLegacyCCMap(cc, norm) {
         let changed = false;
         const s = this._state;
         Object.keys(s.midi.map).forEach(key => {
@@ -95,21 +279,20 @@ export class MidiManager {
                     const def = layer.uniformsDef[parsed.uKey];
                     const v = def.min + norm * (def.max - def.min);
                     layer.uniforms[parsed.uKey].value = v;
-                    // Update slider UI
                     const slider = document.getElementById(`slider-${key}`);
                     if (slider) {
                         slider.value = v;
-                        slider.previousElementSibling.lastElementChild.textContent = v.toFixed(2);
+                        const valDisplay = slider.previousElementSibling && slider.previousElementSibling.lastElementChild;
+                        if (valDisplay) valDisplay.textContent = v.toFixed(2);
                     }
                     changed = true;
                 }
             }
         });
-
         if (changed) this._bus.emit('project:autosave');
     }
 
-    // --- MIDI Learn ---
+    // ---------- MIDI Learn ----------
 
     initLearnUI() {
         const btn = document.getElementById('midi-learn-btn');
@@ -124,8 +307,9 @@ export class MidiManager {
         } else {
             learn.active = true;
             learn.targetMapKey = null;
+            learn.targetBindingId = null;
             this._updateLearnButton(true);
-            this._bus.emit('toast', { msg: 'MIDI Learn: click a parameter slider, then move a MIDI knob', type: 'info' });
+            this._bus.emit('toast', { msg: 'MIDI Learn: click a slider OR press a MIDI key to capture', type: 'info' });
         }
     }
 
@@ -133,8 +317,34 @@ export class MidiManager {
         const learn = this._state.midi.learn;
         learn.active = false;
         learn.targetMapKey = null;
+        learn.targetBindingId = null;
         this._clearLearnHighlight();
         this._updateLearnButton(false);
+        if (this._learnResolver) {
+            this._learnResolver(null);
+            this._learnResolver = null;
+        }
+    }
+
+    /**
+     * Arm learn mode and return a Promise that resolves to the next MIDI signature.
+     * Used by the Config modal to bind any target.
+     * @param {Object} opts - { description?: string }
+     */
+    armLearnOnce(opts = {}) {
+        this.cancelLearn();
+        const learn = this._state.midi.learn;
+        learn.active = true;
+        learn.targetMapKey = null;
+        learn.targetBindingId = '__awaiting__';
+        this._updateLearnButton(true);
+        this._bus.emit('toast', {
+            msg: opts.description ? `MIDI Learn: ${opts.description}` : 'MIDI Learn: move a control or press a key',
+            type: 'info'
+        });
+        return new Promise(resolve => {
+            this._learnResolver = resolve;
+        });
     }
 
     /**
@@ -147,7 +357,6 @@ export class MidiManager {
         learn.targetMapKey = mapKey;
         this._clearLearnHighlight();
 
-        // Highlight the target slider
         const slider = document.getElementById(`slider-${mapKey}`);
         if (slider) {
             slider.classList.add('midi-learn-target');
@@ -155,36 +364,58 @@ export class MidiManager {
         }
 
         const label = this.getMidiBindingLabel(mapKey);
-        this._bus.emit('toast', { msg: `Waiting for MIDI CC → ${label}`, type: 'info' });
+        this._bus.emit('toast', { msg: `Waiting for MIDI → ${label}`, type: 'info' });
     }
 
-    _completeMidiLearn(cc) {
+    _completeLearn(captured) {
         const learn = this._state.midi.learn;
-        const mapKey = learn.targetMapKey;
 
-        // Check for conflict
-        const existingKey = this.findMapKeyByCC(cc);
-        if (existingKey && existingKey !== mapKey) {
-            const existingLabel = this.getMidiBindingLabel(existingKey);
-            delete this._state.midi.map[existingKey];
-            // Clear the old CC input
-            const oldInput = document.querySelector(`input[data-map-key="${existingKey}"]`);
-            if (oldInput) oldInput.value = '';
-            this._bus.emit('toast', { msg: `CC ${cc} reassigned from ${existingLabel}`, type: 'info' });
+        // Generic learn path (from Config modal via armLearnOnce)
+        if (this._learnResolver) {
+            const resolve = this._learnResolver;
+            this._learnResolver = null;
+            this.cancelLearn();
+            resolve(captured);
+            return;
         }
 
-        // Apply mapping
-        this._state.midi.map[mapKey] = cc;
+        // Slider-learn path (legacy CC→uniform map path + auto-create binding if Note/PC)
+        const mapKey = learn.targetMapKey;
+        if (!mapKey) {
+            this.cancelLearn();
+            return;
+        }
 
-        // Update the CC input in the UI
-        const ccInput = document.querySelector(`input[data-map-key="${mapKey}"]`);
-        if (ccInput) ccInput.value = cc;
+        // If capture is CC: use legacy map for continuous uniform control
+        if (captured.type === 'cc') {
+            const existingKey = this.findMapKeyByCC(captured.number);
+            if (existingKey && existingKey !== mapKey) {
+                const existingLabel = this.getMidiBindingLabel(existingKey);
+                delete this._state.midi.map[existingKey];
+                const oldInput = document.querySelector(`input[data-map-key="${existingKey}"]`);
+                if (oldInput) oldInput.value = '';
+                this._bus.emit('toast', { msg: `CC ${captured.number} reassigned from ${existingLabel}`, type: 'info' });
+            }
+            this._state.midi.map[mapKey] = captured.number;
+            const ccInput = document.querySelector(`input[data-map-key="${mapKey}"]`);
+            if (ccInput) ccInput.value = captured.number;
 
-        const label = this.getMidiBindingLabel(mapKey);
-        this._bus.emit('toast', { msg: `CC ${cc} → ${label}`, type: 'success' });
-        this._bus.emit('project:autosave');
+            const label = this.getMidiBindingLabel(mapKey);
+            this._bus.emit('toast', { msg: `CC ${captured.number} → ${label}`, type: 'success' });
+            this._bus.emit('project:autosave');
+        } else {
+            // Note / PC → auto-create a uniform.set binding (cannot trigger a uniform though)
+            // For now, emit advisory toast and skip — users pick the action in Config modal for non-CC.
+            const parsed = this.parseMidiMapKey(mapKey);
+            if (parsed && this._bindings) {
+                // We can't sensibly map Note/PC to continuous uniform; tell the user.
+                this._bus.emit('toast', {
+                    msg: `Note/PC cannot drive a continuous uniform. Use MIDI Config for action mappings.`,
+                    type: 'info'
+                });
+            }
+        }
 
-        // Exit learn mode
         this.cancelLearn();
     }
 
@@ -207,7 +438,20 @@ export class MidiManager {
         }
     }
 
-    // --- Utility methods ---
+    // ---------- Panic ----------
+
+    /** Release all momentary, clear solo, turn off blackout, cancel Learn. */
+    panic() {
+        this.cancelLearn();
+        if (this._bindings) this._bindings.releaseAllMomentary();
+        this._state.soloLayerId = null;
+        this._state.blackout = false;
+        this._bus.emit('layer:solo', { layerId: null, source: 'panic' });
+        this._bus.emit('app:blackout', { active: false, source: 'panic' });
+        this._bus.emit('toast', { msg: 'MIDI Panic: state cleared', type: 'info' });
+    }
+
+    // ---------- Utility ----------
 
     normalizeMidiValue(raw) {
         if (typeof raw !== 'number' || isNaN(raw)) return 0;
@@ -263,5 +507,20 @@ export class MidiManager {
                 delete this._state.midi.map[k];
             }
         });
+        if (this._bindings) this._bindings.removeForLayer(layer.id);
+    }
+
+    // ---------- Hooks for simulation (used by tests / console) ----------
+
+    _emulateCC(ch, cc, val01) {
+        this._handleCC({ controller: { number: cc }, message: { channel: ch }, value: val01 });
+    }
+    _emulateNote(ch, num, on, vel = 1) {
+        this._handleNote({ note: { number: num, attack: vel }, message: { channel: ch } }, !!on);
+    }
+    _emulatePC(ch, num) {
+        this._handlePC({ value: num, message: { channel: ch } });
     }
 }
+
+export { buildSignature, parseSignature, formatSignature, SIGNATURE_CHANNEL_OMNI };

--- a/src/persistence/project-io.js
+++ b/src/persistence/project-io.js
@@ -39,13 +39,19 @@ export class ProjectIO {
     }
 
     buildProjectPayload() {
+        const s = this._state;
         return {
-            version: '1.0',
+            version: '1.1',
             savedAt: new Date().toISOString(),
-            scenes: this._state.scenes,
-            midi: { map: this._state.midi.map },
+            scenes: s.scenes,
+            midi: {
+                map: s.midi.map,
+                bindings: s.midi.bindings,
+                clock: { enabled: s.midi.clock.enabled, ignoreTransport: s.midi.clock.ignoreTransport }
+            },
             sync: this._bpmSync.serializeSyncState(),
-            crossfade: { durationBeats: this._state.crossfade.durationBeats }
+            crossfade: { durationBeats: s.crossfade.durationBeats },
+            app: { blackout: !!s.blackout }
         };
     }
 
@@ -78,16 +84,23 @@ export class ProjectIO {
 
         let incomingScenes = null;
         let incomingMap = {};
+        let incomingBindings = [];
+        let incomingClock = null;
         let incomingSync = null;
         let incomingCrossfade = null;
+        let incomingApp = null;
 
         if (Array.isArray(normalizedData)) {
             incomingScenes = normalizedData;
         } else if (normalizedData && Array.isArray(normalizedData.scenes)) {
             incomingScenes = normalizedData.scenes;
-            incomingMap = (normalizedData.midi && normalizedData.midi.map) ? normalizedData.midi.map : {};
+            const midi = normalizedData.midi || {};
+            incomingMap = midi.map || {};
+            incomingBindings = Array.isArray(midi.bindings) ? midi.bindings : [];
+            incomingClock = midi.clock && typeof midi.clock === 'object' ? midi.clock : null;
             incomingSync = normalizedData.sync && typeof normalizedData.sync === 'object' ? normalizedData.sync : null;
             incomingCrossfade = normalizedData.crossfade && typeof normalizedData.crossfade === 'object' ? normalizedData.crossfade : null;
+            incomingApp = normalizedData.app && typeof normalizedData.app === 'object' ? normalizedData.app : null;
         }
         if (!Array.isArray(incomingScenes)) return false;
 
@@ -119,6 +132,7 @@ export class ProjectIO {
                     key: layerData.key,
                     blend: Number.isFinite(blendRaw) ? Math.max(0, Math.min(9, Math.round(blendRaw))) : 0,
                     opacity: Number.isFinite(opacityRaw) ? Math.max(0, Math.min(1, opacityRaw)) : 1,
+                    muted: !!layerData.muted,
                     fragmentShader: typeof layerData.fragmentShader === 'string' ? layerData.fragmentShader : shaderDef.fragmentShader,
                     uniformsDef: this._sceneManager.sanitizeUniformsDef(layerData.uniformsDef, shaderDef.uniforms),
                     uniformValues: (layerData.uniformValues && typeof layerData.uniformValues === 'object' && !Array.isArray(layerData.uniformValues))
@@ -135,6 +149,24 @@ export class ProjectIO {
         this._sceneManager.cancelCrossfade({ silent: true });
         this._state.scenes = scenes;
         this._state.midi.map = this._midiManager.normalizeMidiMapKeys(incomingMap);
+        this._state.midi.bindings = incomingBindings
+            .filter(b => b && typeof b === 'object' && typeof b.signature === 'string' && b.action && typeof b.action === 'object')
+            .map(b => ({
+                id: typeof b.id === 'string' ? b.id : undefined,
+                signature: b.signature,
+                label: typeof b.label === 'string' ? b.label : '',
+                action: {
+                    type: b.action.type,
+                    target: b.action.target && typeof b.action.target === 'object' ? b.action.target : {},
+                    behavior: typeof b.action.behavior === 'string' ? b.action.behavior : null,
+                    invert: !!b.action.invert
+                }
+            }));
+        if (incomingClock) {
+            this._state.midi.clock.enabled = !!incomingClock.enabled;
+            this._state.midi.clock.ignoreTransport = !!incomingClock.ignoreTransport;
+        }
+        this._state.blackout = !!(incomingApp && incomingApp.blackout);
 
         if (incomingSync) this._bpmSync.applySyncState(incomingSync);
         else this._bpmSync.refreshBpmUI();
@@ -153,6 +185,9 @@ export class ProjectIO {
         this._state.sceneIdx = -1;
         this._sceneManager.renderSceneList();
         this._sceneManager.switchScene(0);
+
+        // Re-emit app-level state so UI updates
+        this._bus.emit('app:blackout', { active: !!this._state.blackout, source: 'load' });
         if (!this._undoManager.restoring) {
             const json = this.serializeProjectPayload();
             localStorage.setItem(this._storageKey, json);
@@ -238,14 +273,26 @@ export class ProjectIO {
     get canRedo() { return this._undoManager.canRedo; }
 
     restoreFromStorage() {
-        const raw = localStorage.getItem(this._storageKey);
+        let raw = localStorage.getItem(this._storageKey);
+        let sourceKey = this._storageKey;
+        if (!raw && Array.isArray(this._state.legacyStorageKeys)) {
+            for (const legacy of this._state.legacyStorageKeys) {
+                const v = localStorage.getItem(legacy);
+                if (v) { raw = v; sourceKey = legacy; break; }
+            }
+        }
         if (!raw) return false;
         try {
             const data = JSON.parse(raw);
-            return this.loadProjectData(data, { source: 'autosave', toastSuccess: false });
+            const ok = this.loadProjectData(data, { source: 'autosave', toastSuccess: false });
+            // If loaded from legacy key, migrate forward and leave legacy alone.
+            if (ok && sourceKey !== this._storageKey) {
+                this.persistToStorage();
+            }
+            return ok;
         } catch (err) {
             console.error('Failed to restore auto-saved project', err);
-            localStorage.removeItem(this._storageKey);
+            localStorage.removeItem(sourceKey);
             return false;
         }
     }

--- a/src/persistence/project-migrator.js
+++ b/src/persistence/project-migrator.js
@@ -8,28 +8,27 @@
  *   crossfade: { durationBeats }, audio: { bands, gains }
  */
 
-const CURRENT_VERSION = '1.0';
+const CURRENT_VERSION = '1.1';
 
 export function migrateProject(data) {
     if (!data || typeof data !== 'object') return data;
 
     const version = data.version || '0.5-alpha';
 
-    // Already V1.0+
     if (version === CURRENT_VERSION) return data;
 
-    // V0.5-alpha → V1.0
-    if (version === '0.5-alpha' || !data.version) {
-        return migrateFrom05(data);
-    }
+    // Chain migrations
+    let out = data;
+    if (version === '0.5-alpha' || !data.version) out = migrateFrom05(out);
+    if (out.version === '1.0') out = migrateFrom10(out);
+    if (out.version === CURRENT_VERSION) return out;
 
-    // Unknown version — pass through with warning
-    console.warn(`Unknown project version: ${version}, attempting load as-is`);
-    return data;
+    console.warn(`Unknown project version: ${out.version}, attempting load as-is`);
+    return out;
 }
 
 function migrateFrom05(data) {
-    const migrated = { ...data, version: CURRENT_VERSION };
+    const migrated = { ...data, version: '1.0' };
 
     // Ensure sync has all V1.0 fields
     if (migrated.sync && typeof migrated.sync === 'object') {
@@ -60,6 +59,28 @@ function migrateFrom05(data) {
     }
 
     return migrated;
+}
+
+/**
+ * V1.0 → V1.1
+ *
+ * V1.1 adds:
+ *   - midi.bindings: [] (action-level bindings)
+ *   - midi.clock:    { enabled, ignoreTransport }
+ *   - layers[].muted: boolean (default false)
+ *   - app: { blackout: false }
+ *
+ * V1.0 projects kept their legacy midi.map (CC → "layerId::uniform").
+ * We leave that in place: MidiManager still applies it alongside bindings,
+ * so existing uniform CC assignments work without migration noise.
+ */
+function migrateFrom10(data) {
+    const midi = (data.midi && typeof data.midi === 'object') ? { ...data.midi } : {};
+    if (!Array.isArray(midi.bindings)) midi.bindings = [];
+    if (!midi.clock || typeof midi.clock !== 'object') {
+        midi.clock = { enabled: false, ignoreTransport: false };
+    }
+    return { ...data, version: CURRENT_VERSION, midi };
 }
 
 export { CURRENT_VERSION };

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -211,6 +211,25 @@ export class Renderer {
         // Render scene A (current layers)
         const readA = this._renderLayerStack(s.layers, this.bufferA, this.bufferB, time, audio, beatState);
 
+        // Blackout short-circuit: present black frame (still keep layer render for thumbnails)
+        if (s.blackout) {
+            this.renderer.setRenderTarget(null);
+            this.renderer.setClearColor(0x000000, 1);
+            this.renderer.clear();
+            this._lastReadBuffer = readA;
+            if (this._popupCtx) this._popupCtx.drawImage(this.renderer.domElement, 0, 0);
+            if (now - this._thumbLastUpdate >= this._thumbIntervalMs) {
+                this._thumbLastUpdate = now;
+                this._updateThumbnails();
+            }
+            const frameEnd2 = performance.now();
+            const frameDelta2 = deps.debugPanel._lastFrameStartMs > 0 ? (frameStart - deps.debugPanel._lastFrameStartMs) : 16.67;
+            deps.debugPanel._lastFrameStartMs = frameStart;
+            if (this._lastLayerTimings) deps.debugPanel.setLayerTimings(this._lastLayerTimings);
+            deps.debugPanel.updateMetrics(frameEnd2, frameDelta2, frameEnd2 - frameStart, frameEnd2 - renderStart);
+            return;
+        }
+
         if (cf.active) {
             // Ensure crossfade buffers exist
             if (!this.crossfadeBufferA) {
@@ -295,8 +314,20 @@ export class Renderer {
         this.renderer.setRenderTarget(read);
         this.renderer.clear();
 
-        let baseIdx = layers.findIndex(l => !l.needsInput);
-        if (baseIdx === -1 && layers.length > 0) baseIdx = 0;
+        // Determine which layers are composited this frame.
+        // Solo takes precedence: only the soloed layer gets through; everyone else is hidden.
+        // Mute hides individually. Layers still render to their own target so thumbnails stay live.
+        // Solo only applies when the solo target is actually in this stack.
+        const soloId = s.soloLayerId;
+        const soloActive = soloId && layers.some(l => l.id === soloId);
+        const isVisible = (l) => {
+            if (l.muted) return false;
+            if (soloActive && l.id !== soloId) return false;
+            return true;
+        };
+
+        let baseIdx = layers.findIndex(l => isVisible(l) && !l.needsInput);
+        if (baseIdx === -1) baseIdx = layers.findIndex(isVisible);
 
         layers.forEach((layer, i) => {
             const layerStart = performance.now();
@@ -322,6 +353,16 @@ export class Renderer {
                 this.copyMat.uniforms.u_texture.value = layer.renderTarget.texture;
                 this.quad.material = this.copyMat;
                 this.renderer.render(this.scene, this.camera);
+            }
+
+            // Skip composition when hidden (mute / solo), but keep per-layer render above
+            // so thumbnails and feedback state stay live.
+            if (!isVisible(layer)) {
+                this._lastLayerTimings.push({
+                    name: (layer.name || `Layer ${i}`) + ' (muted)',
+                    ms: performance.now() - layerStart
+                });
+                return;
             }
 
             const isBase = i === baseIdx;

--- a/src/scene/scene-manager.js
+++ b/src/scene/scene-manager.js
@@ -26,6 +26,16 @@ export class SceneManager {
         this._hideModal = null;
 
         bus.on('crossfade:complete', () => this._finalizeCrossfade());
+
+        // MIDI-driven navigation
+        bus.on('scene:recall', ({ index }) => this.switchScene(index));
+        bus.on('scene:step', ({ delta }) => {
+            const n = this._state.scenes.length;
+            if (n === 0) return;
+            const cur = this._state.sceneIdx >= 0 ? this._state.sceneIdx : 0;
+            const next = (((cur + delta) % n) + n) % n;
+            this.switchScene(next);
+        });
     }
 
     /** Proxy accessors for ProjectIO to call */
@@ -304,6 +314,7 @@ export class SceneManager {
             key: l.key,
             blend: l.blend,
             opacity: l.opacity,
+            muted: !!l.muted,
             fragmentShader: l.fragmentShader,
             uniformsDef: JSON.parse(JSON.stringify(l.uniformsDef)),
             uniformValues: Object.keys(l.uniformsDef).reduce((acc, k) => {

--- a/src/sync/bpm-sync.js
+++ b/src/sync/bpm-sync.js
@@ -32,6 +32,23 @@ export class BpmSync {
 
         // Scene manager injected after construction
         this._sceneManager = null;
+
+        // MIDI Clock listeners
+        bus.on('midi:clock-tick', ({ bpm }) => {
+            if (!this._state.midi.clock.enabled) return;
+            this.setBpm(bpm, { resetPhase: false, keepTapHistory: true });
+            if (this._bpmInputEl) this._bpmInputEl.disabled = true;
+        });
+        bus.on('midi:clock-start', () => {
+            if (!this._state.midi.clock.enabled) return;
+            this.resetBeatPhase();
+            this.setBeatRunning(true);
+        });
+        bus.on('midi:clock-stop', () => {
+            if (!this._state.midi.clock.enabled) return;
+            this.setBeatRunning(false);
+        });
+        bus.on('bpm:tap', () => this.tapTempo());
     }
 
     /** Inject scene manager (avoids circular dependency). */
@@ -130,11 +147,15 @@ export class BpmSync {
     refreshBpmUI() {
         const s = this._state;
         const runToggle = document.getElementById('beat-run-toggle');
+        const clockOn = s.midi && s.midi.clock && s.midi.clock.enabled;
         if (this._bpmInputEl && document.activeElement !== this._bpmInputEl) {
             this._bpmInputEl.value = s.bpm.toFixed(1);
+            this._bpmInputEl.disabled = !!clockOn;
+            this._bpmInputEl.title = clockOn ? 'BPM driven by MIDI Clock' : '';
         }
         if (this._bpmDisplayEl) {
-            this._bpmDisplayEl.textContent = `${s.bpm.toFixed(1)} BPM${s.bpmRunning ? '' : ' (PAUSE)'}`;
+            const src = clockOn ? ' ⧗MIDI' : '';
+            this._bpmDisplayEl.textContent = `${s.bpm.toFixed(1)} BPM${s.bpmRunning ? '' : ' (PAUSE)'}${src}`;
         }
         if (runToggle) runToggle.checked = s.bpmRunning;
     }

--- a/src/ui/ui-controller.js
+++ b/src/ui/ui-controller.js
@@ -23,6 +23,7 @@ export class UIController {
         this._bpmSync = deps.bpmSync;
         this._projectIO = deps.projectIO;
         this._midiManager = deps.midiManager;
+        this._midiConfigUI = deps.midiConfigUI;
         this._audio = deps.audio;
     }
 
@@ -101,6 +102,12 @@ export class UIController {
         });
 
         this._buildShaderAccordion(hideModal);
+
+        // --- Blackout button ---
+        const blackoutBtn = document.getElementById('blackout-btn');
+        if (blackoutBtn) {
+            blackoutBtn.onclick = () => this._bus.emit('app:blackout', { active: !this._state.blackout, source: 'ui' });
+        }
 
         // --- Global Shortcuts ---
         this._initGlobalShortcuts(hideModal);
@@ -309,11 +316,47 @@ export class UIController {
                 return;
             }
 
+            // 1-9 — scene recall, 0 — blackout toggle
+            if (!ctrlOrMeta && !e.altKey && !isTextInput
+                && !this._sceneManager.isModalOpen('code-modal')
+                && !this._sceneManager.isModalOpen('shader-modal')
+                && !(this._midiConfigUI && this._midiConfigUI.isOpen())) {
+                if (/^[1-9]$/.test(key)) {
+                    e.preventDefault();
+                    const idx = parseInt(key, 10) - 1;
+                    if (idx < this._state.scenes.length) this._bus.emit('scene:recall', { index: idx });
+                    return;
+                }
+                if (key === '0') {
+                    e.preventDefault();
+                    this._bus.emit('app:blackout', { active: !this._state.blackout, source: 'key' });
+                    return;
+                }
+                if (key === 'b') {
+                    e.preventDefault();
+                    if (e.shiftKey) this._bus.emit('app:panic', {});
+                    else this._bus.emit('app:blackout', { active: !this._state.blackout, source: 'key' });
+                    return;
+                }
+            }
+
             // Escape — cancel MIDI Learn first, then close modals
             if (e.key === 'Escape') {
                 if (this._state.midi.learn.active) {
                     e.preventDefault();
                     this._midiManager.cancelLearn();
+                    return;
+                }
+                const bindingEditor = document.getElementById('midi-binding-editor');
+                if (bindingEditor && !bindingEditor.classList.contains('hidden')) {
+                    e.preventDefault();
+                    bindingEditor.classList.add('opacity-0');
+                    setTimeout(() => bindingEditor.classList.add('hidden'), 150);
+                    return;
+                }
+                if (this._midiConfigUI && this._midiConfigUI.isOpen()) {
+                    e.preventDefault();
+                    this._midiConfigUI.close();
                     return;
                 }
                 if (this._sceneManager.isModalOpen('code-modal') && this._editorController.editorClose) {

--- a/styles.css
+++ b/styles.css
@@ -63,3 +63,45 @@
         .layer-panel-collapsed .layer-panel-arrow {
             transform: rotate(180deg);
         }
+
+        /* ── Layer M/S buttons & muted state ───────────────────── */
+        .layer-mute-btn.layer-flag-on {
+            background: rgba(127, 29, 29, 0.55);
+            color: #fca5a5;
+            border-color: #f87171;
+        }
+        .layer-solo-btn.layer-flag-on {
+            background: rgba(133, 77, 14, 0.55);
+            color: #fde68a;
+            border-color: #facc15;
+        }
+        .layer-card.layer-muted {
+            opacity: 0.45;
+            filter: grayscale(0.55);
+        }
+        .layer-card.layer-muted::before {
+            content: 'MUTED';
+            position: absolute;
+            top: 4px;
+            right: 8px;
+            font-size: 8px;
+            color: #fca5a5;
+            letter-spacing: 0.1em;
+            font-weight: 700;
+            pointer-events: none;
+        }
+
+        /* ── MIDI activity pulse (header dot) ─────────────────── */
+        @keyframes midi-pulse-anim {
+            0%   { box-shadow: 0 0 0 0 rgba(192, 132, 252, 0.6); }
+            100% { box-shadow: 0 0 0 6px rgba(192, 132, 252, 0); }
+        }
+        #midi-status-dot.midi-pulse {
+            animation: midi-pulse-anim 180ms ease-out;
+        }
+
+        /* ── MIDI Config tab active state ─────────────────────── */
+        .midi-tab[data-active="true"] {
+            color: #e9d5ff;
+            border-bottom-color: #a855f7;
+        }


### PR DESCRIPTION
## Summary

VJ ツール向けに MIDI システムを大幅拡張し、レイヤー切替 (シーン呼び出し + 個別 MUTE/SOLO)、MIDI Config モーダル、ショートカット類の UX 改善を一体で追加します。CC→uniform の既存マップは legacy として保持しているため、既存プロジェクトは読み込むだけで動作します。

### MIDI エンジン拡張

- **受信**: CC / **Note On/Off** / **Program Change** / **MIDI Clock (24 PPQN)** / Start/Stop に対応。
- **デバイス管理**: 入力デバイスごとの enable/disable を `state.midi.devices` と `localStorage: vj_midi_devices` に保持。
- **MIDI Panic**: Learn キャンセル、momentary 解除、solo 解除、blackout 解除を一括実行。
- **活動モニタ**: `midi:activity` イベントでヘッダドット点滅と Config 内モニタを駆動。

### アクション・バインディング層 (新規)

`src/midi/midi-actions.js` (カタログ) と `src/midi/midi-bindings.js` (dispatch) を追加。

- Signature 形式: `"type|channel|number"` (channel 0 は omni)。
- 提供アクション: `scene.recall` / `scene.next` / `scene.prev` / `layer.mute` / `layer.solo` / `layer.select` / `layer.opacity` / `layer.blend.next` / `uniform.set` / `crossfade.mix` / `bpm.tap` / `app.blackout` / `app.panic`。
- Note は `trigger` / `toggle` / `momentary` を選択可能。CC は 0.5 を閾値にボタン的挙動もサポート。
- ディスパッチは EventBus 経由でアクションイベントを発火し、Scene/Layer/BPM モジュールを疎結合に保ちます。

### レイヤー MUTE / SOLO / Blackout

- `layer.muted`: renderer は個別描画は継続 (サムネイル / feedback が凍らない)、合成のみスキップ。
- `state.soloLayerId`: solo 中は他レイヤーの合成を抑制。
- `state.blackout`: メイン出力を黒フレームで短絡。
- レイヤーカードに **M** / **S** ボタン、`.layer-muted` / `.active` の視覚状態を追加。

### MIDI Config モーダル (新規)

ヘッダの `⚙` ボタンから開く 4 タブ構成:

- **MAPPINGS**: 表形式、カテゴリフィルタ、Learn → Add、個別編集モーダル (Action / Target / Behavior / Label)。
- **DEVICES**: 接続状態と enable/disable トグル + LIVE MONITOR (直近 40 行の受信ログ)。
- **CLOCK / SYNC**: Clock 受信 ON/OFF、Start/Stop 無視、推定 BPM / Transport 表示。
- **GLOBAL**: MIDI Panic、全バインディング削除、JSON export/import、ショートカット表。

### UX 改善

- ヘッダに **BLACKOUT** ボタンとキャンバス上の赤ラベル。
- キーボード: `1`–`9` = シーン呼び出し、`0` / `B` = blackout、`Shift+B` = Panic、`T` = tap (既存)。
- Escape: Learn → Binding Editor → MIDI Config → 既存モーダル の順で閉じる。
- Clock 有効時は手動 BPM 入力を disable し、ソースを表示。

### 永続化 (schema v1.1)

- 保存対象に `midi.bindings` / `midi.clock` / `layers[].muted` / `app.blackout` を追加。
- `project-migrator.js`: `0.5-alpha → 1.0 → 1.1` を連鎖適用。legacy `midi.map` は保持。
- `restoreFromStorage()` は旧キー `vj_project_autosave_v0_5` をフォールバック読み込みし、自動的に新キーへ保存。

## Test plan

- [x] `npm run build` が成功する
- [x] Node 簡易テスト — signature 構築/解析/omni match、scene.recall on note、layer.mute toggle、momentary on/off エッジ、uniform.set on cc、PC → scene.recall フォールバック、actionSupports の境界をいずれも確認
- [x] Migrator — 0.5-alpha と 1.0 いずれも 1.1 に展開され、legacy `midi.map` が温存されることを確認
- [ ] ブラウザ手動確認 (要 Web MIDI 対応環境)
  - [ ] シーン 2 つ作成 → Note 36/37 に `scene.recall` → Note で切替 (crossfade 設定も尊重)
  - [ ] レイヤー 2 枚 → Note 40=mute TOGGLE, Note 41=solo → 期待通り動く
  - [ ] CC74 = `uniform.set` の Learn 完了 → ノブで uniform が動く
  - [ ] PC 3 = `scene.recall` target 未指定 → PC 番号が index にフォールバック
  - [ ] Clock タブで有効化 → 外部 Clock で BPM が追従 / 手動 BPM が disabled
  - [ ] Shift+B / ヘッダ Panic → solo / blackout / 保持 note が解除される
  - [ ] v1.0 プロジェクトの import → bindings 空で起動、既存 CC map で uniform 動作

https://claude.ai/code/session_01MmryBxHzoEywBgoiroaFvM