### PR TITLE
fix(undo): undo 後に redo スタックが消える不具合の修正

### DIFF
--- a/src/core/undo-manager.js
+++ b/src/core/undo-manager.js
@@ -25,7 +25,13 @@ export class UndoManager {
      */
     commit(snapshotJSON) {
         if (this._restoring) return;
-        if (snapshotJSON === this._lastCommitted) return;
+        // Dedup on *content*, ignoring volatile fields (e.g. `savedAt`, which is a fresh
+        // timestamp on every serialize). Otherwise two snapshots of the identical project
+        // state never compare equal, so a deferred autosave fired by a restore (undo/redo
+        // schedules a save via queueMicrotask → setTimeout, which runs after `restoring`
+        // has already been reset) re-commits the same state and wipes the redo stack.
+        // Comparing normalized content makes that re-commit a no-op.
+        if (this._normalize(snapshotJSON) === this._normalize(this._lastCommitted)) return;
         if (this._lastCommitted !== null) {
             this._undoStack.push(this._lastCommitted);
             if (this._undoStack.length > this._maxHistory) {
@@ -70,6 +76,24 @@ export class UndoManager {
         this._undoStack = [];
         this._redoStack = [];
         this._lastCommitted = snapshotJSON;
+    }
+
+    /**
+     * Strip volatile fields so two serializations of the same logical state compare
+     * equal. Currently only the top-level `savedAt` timestamp. Returns the input
+     * unchanged if it isn't parseable JSON (defensive — never throws).
+     * @param {string|null} snapshotJSON
+     * @returns {string|null}
+     */
+    _normalize(snapshotJSON) {
+        if (snapshotJSON == null) return snapshotJSON;
+        try {
+            const obj = JSON.parse(snapshotJSON);
+            if (obj && typeof obj === 'object') delete obj.savedAt;
+            return JSON.stringify(obj);
+        } catch {
+            return snapshotJSON;
+        }
     }
 
     /** Prevent commits during restore operations */


### PR DESCRIPTION
## 概要

undo を実行した直後に redo スタックが破棄され、**redo が常に効かなくなる**不具合を修正します。

## 原因（トレース）

1. `ProjectIO.undo()` / `redo()` は `restoring=true` をセット → `loadProjectData()` を呼ぶ → `finally` で `restoring=false` を**同期的に**リセットします。
2. `loadProjectData()` は内部で `switchScene()` → `_instantSwitch()` を呼び、そこで `queueMicrotask(() => emit('project:autosave'))`（`scene-manager.js:248`）が**非同期に**オートセーブを予約します。
3. `project:autosave` → `queueAutoSave()` → `setTimeout(…, 200)` → `persistToStorage()` → `undoManager.commit(json)` という流れで、`commit()` が走るのは `restoring` が**すでに false に戻った後**です。そのため `commit()` 冒頭の `if (this._restoring) return;` ガードは効きません。
4. もう一方のガード `if (snapshotJSON === this._lastCommitted) return;` も効きません。`buildProjectPayload()` が `savedAt: new Date().toISOString()`（`project-io.js:45`）を毎回埋め込むため、**同一状態でも再シリアライズすると文字列が必ず変わり** `_lastCommitted` と一致しないからです。
5. 結果、`commit()` は通常分岐に入り `this._redoStack = []`（`undo-manager.js`）を実行 → **redo が破棄**されます。

## 修正内容

`UndoManager.commit()` の重複判定を、**揮発フィールド（`savedAt`）を除いた内容**で比較するようにしました（`_normalize()` を追加）。これにより、restore が引き起こす「同一状態の再 commit」が no-op になり、redo スタックが保持されます。

非同期タイミングに依存しない決定的な修正です。副次的に、内容変化を伴わないオートセーブ（タイムスタンプだけ違うもの）が無駄な undo エントリを作る問題も解消します。

## 検証

- `UndoManager` の単体シミュレーション（undo → 遅延オートセーブ再 commit → redo）で、修正前は redo が消えるシナリオが、修正後は `canRedo=true` を維持し redo が正しく前状態を返すことを確認。
- `npm run build`（esbuild）成功。

## 補足: 別途報告した未修正の論点（このPRには含まず）

レビューで以下も観測しています:
- `audio` 設定が `buildProjectPayload()` に含まれず、保存のたびに失われる（migrator は `audio` を生成する）。
- 読込時に `id` 無しの MIDI binding が `id: undefined` になり、削除や momentary 状態管理が衝突する。
- legacy CC マップが MIDI チャンネルを無視する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMzppFhrvAC8pEraahrCWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMzppFhrvAC8pEraahrCWQ)_