### PR TITLE
Add Live Engine performance guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 .DS_Store
+.playwright-mcp/
+glsl-vj-v12-*.png

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GLSL-Multi-layer-VJ-WEB
 
-GLSLシェーダーを複数レイヤーで合成し、ブラウザ上でVJパフォーマンスを行うためのアプリケーションです。
+GLSLシェーダーを複数レイヤーで合成し、ブラウザ上でVJパフォーマンスを行うためのライブツールです。
 
 ## 特徴
 
@@ -9,9 +9,14 @@ GLSLシェーダーを複数レイヤーで合成し、ブラウザ上でVJパ�
 - SortableJS によるレイヤーのドラッグ＆ドロップ並び替え
 - ポップアップウィンドウへの出力と録画(WebM)機能
 - WebMidi.js による外部MIDIコントローラー連携 / Beat Sync
+- Performance Guard による内部 render-scale 自動調整、thumbnail cadence 調整、hidden layer freeze
+- Live Engine パネルによる scene/layer/FPS/render-scale/MIDI/crossfade の即時確認
+- Live Apply (`Ctrl+Enter`) によるエディタを閉じない GLSL コンパイル反映
 - esbuild による `src/` モジュールのバンドル
 
 ## ローカルで起動する
+
+前提: Node.js 18 以上。
 
 ```bash
 npm install
@@ -27,7 +32,12 @@ npm run serve        # http://localhost:3000/ で index.html を配信
 - `styles.css` – 共通スタイル
 - `src/` – アプリケーション本体（モジュラー構成）
   - `src/main.js` – 起動シーケンス
-  - `src/app/` – VJApp 本体およびモジュール
+  - `src/core/` – AppState / EventBus / Undo
+  - `src/renderer/` – WebGL render pipeline / compositing
+  - `src/layer/` – レイヤー生成、UI、uniform、MIDI legacy map
+  - `src/scene/` – シーン CRUD / crossfade
+  - `src/midi/` – MIDI device, action bindings, config UI
+  - `src/performance/` – Performance Guard / Live Engine state
   - `src/shaders/` – 組み込みシェーダーレジストリ
 - `esbuild.config.mjs` – ビルド設定（`src/main.js` → `dist/app.bundle.js`）
 - `.github/workflows/deploy.yml` – GitHub Pages への自動デプロイ
@@ -50,9 +60,22 @@ npm run serve        # http://localhost:3000/ で index.html を配信
 - Three.js `0.150.0`
 - Monaco Editor `0.45.0`
 - SortableJS `1.15.0`
-- WebMidi.js (`@latest`)
+- WebMidi.js `3.1.16`
 
-Tailwind と WebMidi はバージョン固定されていないため、本番運用時はピン留めを検討してください。
+Tailwind CDN はバージョン固定されていないため、本番運用時はビルド済みCSSへ移行するか、固定配信へ置き換えてください。
+
+## Live Operation
+
+- `G` – Performance Guard の ON/OFF
+- `Shift+G` – Quality / Balanced / Performance profile の切り替え
+- `Ctrl+Enter` – GLSL Editor の Live Apply（エディタを閉じずに反映）
+- `Ctrl+S` – GLSL Editor の Apply、またはプロジェクト export
+- `1..9` – シーン呼び出し
+- `0` / `B` – blackout
+- `Shift+B` – MIDI Panic
+- `T` – tap tempo
+
+Performance Guard は保存スキーマ v1.2 の `performance` に設定を保存します。旧 v0.5 / v1.0 / v1.1 プロジェクトは `project-migrator.js` で v1.2 に補完されます。
 
 ## ライセンス
 

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>GLSL Multi layer VJ V0.5 alpha "Memory Keeper"</title>
+    <title>GLSL Multi-layer VJ v1.2 "Live Engine"</title>
+    <link rel="icon" href="data:,">
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- SortableJS -->
@@ -15,7 +16,7 @@
     <link rel="preload" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/editor/editor.main.js" as="script">
     <link rel="preload" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/editor/editor.main.css" as="style">
     <!-- WebMidi.js -->
-    <script src="https://cdn.jsdelivr.net/npm/webmidi@latest/dist/iife/webmidi.iife.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/webmidi@3.1.16/dist/iife/webmidi.iife.js"></script>
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="./styles.css">
@@ -28,14 +29,14 @@
             <button id="sidebar-toggle-btn" class="text-slate-400 hover:text-white transition-colors p-1 -ml-1" title="Toggle Sidebar (Tab)">
                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
             </button>
-            <h1 class="font-bold text-lg tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-emerald-400 to-cyan-500">GLSL VJ <span class="text-[10px] text-slate-500 font-mono border border-slate-800 rounded px-1 ml-1">v1.0</span></h1>
+            <h1 class="font-bold text-lg tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-emerald-400 to-cyan-500">GLSL VJ <span class="text-[10px] text-slate-500 font-mono border border-slate-800 rounded px-1 ml-1">v1.2</span></h1>
             <div class="h-4 w-px bg-slate-800 mx-2"></div>
             <div class="flex items-center gap-3 text-[10px] font-mono text-slate-500">
                 <span id="fps-counter" class="text-green-500 w-16">FPS: --</span>
                 <span id="resolution-display">1920x1080</span>
             </div>
         </div>
-        
+
         <!-- Audio Visualizer -->
         <div class="flex items-center gap-3 flex-1 justify-center max-w-lg mx-4" id="audio-visualizer-container">
             <button id="audio-enable-btn" class="text-[10px] font-bold bg-slate-900 hover:bg-slate-800 text-purple-400 px-2 py-1.5 rounded border border-purple-900/50 transition-colors uppercase tracking-widest whitespace-nowrap">
@@ -123,6 +124,41 @@
                     <input id="preserve-buffer-toggle" type="checkbox" class="accent-purple-500">
                     Preserve Buffer (Reload)
                 </label>
+                <div class="live-engine-panel space-y-2 pt-2 border-t border-slate-800/70">
+                    <div class="flex items-center justify-between">
+                        <span class="text-[10px] font-bold text-slate-400 tracking-widest">LIVE ENGINE</span>
+                        <span id="performance-status" class="performance-status-pill" data-state="nominal">NOMINAL</span>
+                    </div>
+                    <div class="grid grid-cols-2 gap-x-3 gap-y-1 text-[10px] font-mono">
+                        <span class="text-slate-500">Scene</span><span id="live-scene" class="text-right text-slate-200 truncate">--</span>
+                        <span class="text-slate-500">Layers</span><span id="live-layers" class="text-right text-slate-200 truncate">--</span>
+                        <span class="text-slate-500">FPS / Frame</span><span class="text-right text-slate-200"><span id="live-fps">--</span> / <span id="live-frame-ms">-- ms</span></span>
+                        <span class="text-slate-500">Render Scale</span><span id="live-render-scale" class="text-right text-emerald-300">100%</span>
+                        <span class="text-slate-500">Crossfade</span><span id="live-crossfade" class="text-right text-cyan-300">idle</span>
+                        <span class="text-slate-500">Last MIDI</span><span id="live-midi-last" class="text-right text-purple-300 truncate">none</span>
+                        <span class="text-slate-500">Thumbnails</span><span id="live-thumbnail-rate" class="text-right text-slate-300">180 ms</span>
+                    </div>
+                    <div class="grid grid-cols-2 gap-2 pt-1">
+                        <label class="flex items-center gap-2 text-[10px] text-slate-400">
+                            <input id="performance-guard-toggle" type="checkbox" class="accent-emerald-500" checked>
+                            Guard
+                        </label>
+                        <label class="flex items-center gap-2 text-[10px] text-slate-400">
+                            <input id="performance-freeze-hidden" type="checkbox" class="accent-amber-500">
+                            Freeze Hidden
+                        </label>
+                        <select id="performance-profile" class="bg-slate-900 text-slate-300 text-[10px] border border-slate-800 rounded px-2 py-1 focus:border-emerald-500 outline-none">
+                            <option value="quality">Quality</option>
+                            <option value="balanced" selected>Balanced</option>
+                            <option value="performance">Performance</option>
+                        </select>
+                        <select id="performance-target-fps" class="bg-slate-900 text-slate-300 text-[10px] border border-slate-800 rounded px-2 py-1 focus:border-emerald-500 outline-none">
+                            <option value="60" selected>60 FPS</option>
+                            <option value="45">45 FPS</option>
+                            <option value="30">30 FPS</option>
+                        </select>
+                    </div>
+                </div>
             </div>
 
             <!-- Scene List -->
@@ -267,6 +303,7 @@
                                 <option value="layer">Layer</option>
                                 <option value="uniform">Uniform</option>
                                 <option value="global">Global</option>
+                                <option value="performance">Performance</option>
                             </select>
                         </div>
                         <div class="flex items-center gap-2">
@@ -337,6 +374,8 @@
                             <div><kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">1</kbd>-<kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">9</kbd> Recall scene 1..9</div>
                             <div><kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">0</kbd> or <kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">B</kbd> Toggle blackout</div>
                             <div><kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">Shift+B</kbd> MIDI Panic</div>
+                            <div><kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">G</kbd> Performance Guard</div>
+                            <div><kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">Shift+G</kbd> Next performance profile</div>
                             <div><kbd class="px-1.5 py-0.5 border border-slate-700 rounded bg-slate-950">T</kbd> Tap tempo</div>
                         </div>
                     </div>
@@ -390,7 +429,9 @@
                     <span id="editor-layer-name" class="text-[10px] text-slate-400 bg-slate-800 px-2 py-1 rounded font-mono">Layer</span>
                 </div>
                 <div class="flex gap-2">
+                    <span id="editor-status" class="text-[10px] text-slate-500 font-mono px-2 py-1.5 truncate max-w-80">Ready</span>
                     <button id="editor-cancel-btn" class="text-[10px] px-3 py-1.5 rounded text-slate-300 hover:bg-slate-700">ESC</button>
+                    <button id="editor-live-apply-btn" class="text-[10px] px-3 py-1.5 rounded bg-emerald-700 hover:bg-emerald-600 text-white font-bold">APPLY LIVE (CTRL+ENTER)</button>
                     <button id="editor-save-btn" class="text-[10px] px-4 py-1.5 rounded bg-blue-600 hover:bg-blue-500 text-white font-bold">APPLY (CTRL+S)</button>
                 </div>
             </div>
@@ -446,7 +487,7 @@
                     </div>
                 </div>
             </div>
-            
+
             <div class="grid grid-cols-12 gap-4 items-start border-t border-slate-800/50 pt-3">
                 <!-- Main Controls -->
                 <div class="col-span-4 space-y-3 border-r border-slate-800/50 pr-4">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "glsl-multi-layer-vj",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "glsl-multi-layer-vj",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "devDependencies": {
-        "esbuild": "^0.20.0"
+        "esbuild": "^0.28.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
-      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -25,13 +25,13 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
-      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -42,13 +42,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
-      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -59,13 +59,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
-      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -76,13 +76,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
-      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -93,13 +93,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
-      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -110,13 +110,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
-      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -127,13 +127,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
-      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -144,13 +144,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
-      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -161,13 +161,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
-      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -178,13 +178,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
-      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -195,13 +195,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
-      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -212,13 +212,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
-      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -229,13 +229,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
-      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -246,13 +246,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
-      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -263,13 +263,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
-      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -280,13 +280,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
-      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -297,13 +297,30 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -314,13 +331,30 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
-      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -331,13 +365,30 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
-      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -348,13 +399,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
-      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -365,13 +416,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
-      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -382,13 +433,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
-      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -399,13 +450,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/esbuild": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -413,32 +464,35 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.2",
-        "@esbuild/android-arm": "0.20.2",
-        "@esbuild/android-arm64": "0.20.2",
-        "@esbuild/android-x64": "0.20.2",
-        "@esbuild/darwin-arm64": "0.20.2",
-        "@esbuild/darwin-x64": "0.20.2",
-        "@esbuild/freebsd-arm64": "0.20.2",
-        "@esbuild/freebsd-x64": "0.20.2",
-        "@esbuild/linux-arm": "0.20.2",
-        "@esbuild/linux-arm64": "0.20.2",
-        "@esbuild/linux-ia32": "0.20.2",
-        "@esbuild/linux-loong64": "0.20.2",
-        "@esbuild/linux-mips64el": "0.20.2",
-        "@esbuild/linux-ppc64": "0.20.2",
-        "@esbuild/linux-riscv64": "0.20.2",
-        "@esbuild/linux-s390x": "0.20.2",
-        "@esbuild/linux-x64": "0.20.2",
-        "@esbuild/netbsd-x64": "0.20.2",
-        "@esbuild/openbsd-x64": "0.20.2",
-        "@esbuild/sunos-x64": "0.20.2",
-        "@esbuild/win32-arm64": "0.20.2",
-        "@esbuild/win32-ia32": "0.20.2",
-        "@esbuild/win32-x64": "0.20.2"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glsl-multi-layer-vj",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "description": "GLSL Multi-layer VJ System",
   "scripts": {
@@ -9,6 +9,6 @@
     "serve": "npx serve -l 3000 ."
   },
   "devDependencies": {
-    "esbuild": "^0.20.0"
+    "esbuild": "^0.28.1"
   }
 }

--- a/progress.md
+++ b/progress.md
@@ -63,3 +63,45 @@ Original prompt (follow-up): "VJ ツールとしての改善を多く行って�
 - Node 簡易テスト: signature 構築/解析/omni match、scene.recall on note、layer.mute toggle、momentary edge on/off、uniform.set on cc、PC → scene.recall fallback、actionSupports の境界をいずれも確認。
 - migrator: 0.5-alpha と 1.0 のプロジェクトがどちらも 1.1 に展開され、legacy midi.map は温存されることを確認。
 - メモ: ブラウザ UI / Web MIDI 実機テストはこの環境では未実施 (手動確認を次のステップで推奨)。
+
+---
+
+## v1.2 — Live Engine / Performance Guard / Live Coding UX (2026-07-06)
+
+Original prompt: "これを再設計するならどうする？現在の仕様を元に更なるブラッシュアップ、革新的なテクノロジー、更なるUI,UX、拡張性、安定性、ライブパフォーマンス性、ライブコーディング適正、MIDI適正、VJ適正など全てをブラッシュアップ、更新、最適化、高性能化、高機能化を行なってください"
+
+### 採用判断
+- 採用: 既存 GLSL/WebGL パイプラインを維持し、内部 render-scale と Live Engine を追加する段階的再設計。
+- 棄却: WebGPU 全面移行。理由は既存 GLSL 資産、Three.js FBO 合成、Monaco live editing、MIDI/scene 保存形式への影響が大きく、今回の目的に対して破壊リスクが高いため。
+
+### Performance Guard (`src/performance/`, `src/renderer/`)
+- 新規 `PerformanceGuard` を追加。`render:metrics` を監視して target FPS に対する frame budget 超過を検出する。
+- 内部 render target サイズを出力解像度から分離。`renderScale` 0.5-1.0 で FBO サイズを縮小し、最終出力へアップスケールする。
+- Quality / Balanced / Performance profile を追加。thumbnail 更新間隔も profile/adaptive level に応じて調整する。
+- `Freeze Hidden` を追加。mute/solo で非表示のレイヤーを保持して、必要時だけ負荷を落とせる。
+- `Renderer` は blackout 中も通常描画中も `render:metrics` を発火するため、監視が途切れない。
+
+### UI / UX
+- Sidebar 上部に `LIVE ENGINE` パネルを追加。scene/layer/FPS/frame/render-scale/crossfade/MIDI/thumbnail cadence を表示。
+- `G` で Performance Guard ON/OFF、`Shift+G` で performance profile cycle。
+- WebMidi.js を `@latest` から `3.1.16` にピン留め。
+- esbuild を `0.28.1` に更新し、dev-server advisory を解消。
+- タイトルと表示バージョンを v1.2 に更新。
+
+### Live Coding
+- GLSL Editor に `APPLY LIVE (CTRL+ENTER)` を追加。成功時にエディタを閉じず、ライブ中に連続調整できる。
+- 既存 `APPLY (CTRL+S)` は従来どおり成功時に閉じる。
+- Compile 成功/失敗を `editor-status` に表示し、toast と Monaco error decoration に同期する。
+
+### MIDI / 保存
+- MIDI action に `performance.guard.toggle` と `performance.profile.next` を追加。
+- MIDI Config filter に Performance を追加。
+- project schema を `1.2` に更新し、`performance` 設定を保存対象へ追加。
+- `project-migrator.js` は `0.5-alpha -> 1.0 -> 1.1 -> 1.2` を連鎖適用する。
+
+### 検証
+- `npm run build` 成功。
+- Node 簡易検証: project migrator (0.5-alpha/1.0/1.1 → 1.2)、Performance MIDI actions、Performance Guard adaptive downshift を確認。
+- `npm audit --json` は 0 vulnerabilities。
+- Playwright: desktop と 390px viewport で初期表示、Live Engine 表示、console error 0 を確認。警告は Tailwind CDN と Three.js global build の既知警告のみ。
+- 未検証: 実 MIDI コントローラー、Web MIDI 権限付与後のブラウザ実機操作、長時間ライブ負荷テスト。

--- a/src/core/app-state.js
+++ b/src/core/app-state.js
@@ -18,6 +18,22 @@ export class AppState {
         this.dprMode = localStorage.getItem('vj_dpr') || '1';
         this.preserveDrawingBuffer = localStorage.getItem('vj_preserve_buffer') === '1';
 
+        // --- Performance Guard ---
+        const savedTargetFps = Number(localStorage.getItem('vj_perf_target_fps'));
+        const savedProfile = localStorage.getItem('vj_perf_profile');
+        this.performance = {
+            guardEnabled: localStorage.getItem('vj_perf_guard') !== '0',
+            targetFps: [30, 45, 60].includes(savedTargetFps) ? savedTargetFps : 60,
+            profile: ['quality', 'balanced', 'performance'].includes(savedProfile) ? savedProfile : 'balanced',
+            renderScale: 1,
+            adaptiveLevel: 0,
+            thumbnailIntervalMs: 180,
+            freezeHiddenLayers: localStorage.getItem('vj_perf_freeze_hidden') === '1',
+            status: 'nominal',
+            avgFrameMs: 16.67,
+            lastReason: 'init'
+        };
+
         // --- MIDI ---
         // map: legacy CC→uniform map, kept for backwards compatibility.
         //      Format: { "layerId::u_key": ccNumber }
@@ -88,9 +104,9 @@ export class AppState {
         this.soloLayerId = null;
 
         // --- Persistence ---
-        // Storage key is versioned; v1.1 adds bindings/clock/blackout etc.
-        this.projectStorageKey = 'vj_project_autosave_v1_1';
-        this.legacyStorageKeys = ['vj_project_autosave_v0_5'];
+        // Storage key is versioned; v1.2 adds Performance Guard prefs.
+        this.projectStorageKey = 'vj_project_autosave_v1_2';
+        this.legacyStorageKeys = ['vj_project_autosave_v1_1', 'vj_project_autosave_v0_5'];
         this.storageErrorShown = false;
 
         // --- Debug ---

--- a/src/editor/editor-controller.js
+++ b/src/editor/editor-controller.js
@@ -28,6 +28,7 @@ export class EditorController {
         this._monaco = null;
         this._monacoU = null;
         this._editorSaveAction = null;
+        this._editorLiveApplyAction = null;
         this._editorClose = null;
         this._editorCommandsBound = false;
         this._errorDecorations = [];
@@ -42,6 +43,12 @@ export class EditorController {
         m.classList.remove('hidden');
         setTimeout(() => m.classList.remove('opacity-0'), 10);
         document.getElementById('editor-layer-name').textContent = layer.name;
+        const status = document.getElementById('editor-status');
+        if (status) {
+            status.textContent = 'Ready';
+            status.classList.remove('text-red-300', 'text-emerald-300');
+            status.classList.add('text-slate-500');
+        }
 
         const sameLayer = this._currentLayerId === layer.id;
         this._currentLayerId = layer.id;
@@ -80,6 +87,7 @@ export class EditorController {
             m.classList.add('opacity-0');
             setTimeout(() => m.classList.add('hidden'), 300);
             this._editorSaveAction = null;
+            this._editorLiveApplyAction = null;
         };
         document.getElementById('editor-cancel-btn').onclick = close;
         this._editorClose = close;
@@ -109,7 +117,8 @@ export class EditorController {
     _bindEditorSave(layer) {
         this._errorDecorations = [];
 
-        const save = () => {
+        const save = (options = {}) => {
+            const closeOnSuccess = options.closeOnSuccess !== false;
             let mat = null;
             try {
                 const fs = this._monaco.getValue();
@@ -130,10 +139,11 @@ export class EditorController {
 
                 const ud = this._layerManager.sanitizeUniformsDef(rawUd, layer.uniformsDef);
                 const s = this._state;
+                const renderSize = this._renderer.getRenderSize ? this._renderer.getRenderSize() : { width: s.width, height: s.height };
 
                 const nextUniforms = {
                     u_time: { value: 0 },
-                    u_resolution: { value: new THREE.Vector2(s.width, s.height) },
+                    u_resolution: { value: new THREE.Vector2(renderSize.width, renderSize.height) },
                     u_bass: { value: 0 }, u_mid: { value: 0 }, u_treble: { value: 0 },
                     u_bpm: { value: s.bpm }, u_beat: { value: 0 }, u_phase: { value: 0 },
                     u_inputTexture: { value: null }, u_webcamTexture: { value: null }, u_prevLayer: { value: null }
@@ -160,13 +170,25 @@ export class EditorController {
                 const card = document.querySelector(`.layer-card[data-id="${layer.id}"]`);
                 this._layerManager.renderLayerUI(layer, { replaceEl: card });
                 this._bus.emit('project:autosave');
-                this._editorClose();
-                this._bus.emit('toast', { msg: 'Shader compiled successfully!', type: 'success' });
+                if (closeOnSuccess) this._editorClose();
+                const status = document.getElementById('editor-status');
+                if (status) {
+                    status.textContent = closeOnSuccess ? 'Applied' : `Live applied ${new Date().toLocaleTimeString()}`;
+                    status.classList.remove('text-red-300');
+                    status.classList.add('text-emerald-300');
+                }
+                this._bus.emit('toast', { msg: closeOnSuccess ? 'Shader compiled successfully!' : 'Shader live-applied', type: 'success' });
             } catch (e) {
                 if (mat) mat.dispose();
                 console.error(e);
                 const errorInfo = this._parseShaderError(e.message || 'Unknown compilation error');
                 this._bus.emit('toast', { msg: errorInfo.message, type: 'error' });
+                const status = document.getElementById('editor-status');
+                if (status) {
+                    status.textContent = errorInfo.message;
+                    status.classList.remove('text-emerald-300');
+                    status.classList.add('text-red-300');
+                }
 
                 if (errorInfo.line && this._monaco) {
                     this._monaco.revealLineInCenter(errorInfo.line);
@@ -185,20 +207,29 @@ export class EditorController {
         };
 
         this._editorSaveAction = save;
-        document.getElementById('editor-save-btn').onclick = save;
+        this._editorLiveApplyAction = () => save({ closeOnSuccess: false });
+        document.getElementById('editor-save-btn').onclick = () => save();
+        const liveBtn = document.getElementById('editor-live-apply-btn');
+        if (liveBtn) liveBtn.onclick = this._editorLiveApplyAction;
 
         if (!this._editorCommandsBound && this._monaco && this._monacoU) {
             this._editorCommandsBound = true;
             const saveKey = monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS;
+            const liveKey = monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter;
             const escKey = monaco.KeyCode.Escape;
             const runSave = () => {
                 if (typeof this._editorSaveAction === 'function') this._editorSaveAction();
+            };
+            const runLiveApply = () => {
+                if (typeof this._editorLiveApplyAction === 'function') this._editorLiveApplyAction();
             };
             const runClose = () => {
                 if (typeof this._editorClose === 'function') this._editorClose();
             };
             this._monaco.addCommand(saveKey, runSave);
             this._monacoU.addCommand(saveKey, runSave);
+            this._monaco.addCommand(liveKey, runLiveApply);
+            this._monacoU.addCommand(liveKey, runLiveApply);
             this._monaco.addCommand(escKey, runClose);
             this._monacoU.addCommand(escKey, runClose);
         }

--- a/src/layer/layer-manager.js
+++ b/src/layer/layer-manager.js
@@ -86,6 +86,7 @@ export class LayerManager {
         if (def.isWebCam) this._renderer.initWebCam();
 
         const s = this._state;
+        const renderSize = this._renderer.getRenderSize ? this._renderer.getRenderSize() : { width: s.width, height: s.height };
         const uniformDefs = this.sanitizeUniformsDef(
             config && config.uniformsDef ? config.uniformsDef : def.uniforms,
             def.uniforms
@@ -106,7 +107,7 @@ export class LayerManager {
             uniformsDef: uniformDefs,
             uniforms: {
                 u_time: { value: 0 },
-                u_resolution: { value: new THREE.Vector2(s.width, s.height) },
+                u_resolution: { value: new THREE.Vector2(renderSize.width, renderSize.height) },
                 u_bass: { value: 0 }, u_mid: { value: 0 }, u_treble: { value: 0 },
                 u_bpm: { value: s.bpm }, u_beat: { value: 0 }, u_phase: { value: 0 },
                 u_inputTexture: { value: null }, u_webcamTexture: { value: null }, u_prevLayer: { value: null }

--- a/src/main.js
+++ b/src/main.js
@@ -19,6 +19,7 @@ import { AppState } from './core/app-state.js';
 import { AudioAnalyzer } from './audio/audio-analyzer.js';
 import { Renderer } from './renderer/renderer.js';
 import { BpmSync } from './sync/bpm-sync.js';
+import { PerformanceGuard } from './performance/performance-guard.js';
 import { MidiManager } from './midi/midi-manager.js';
 import { MidiBindings } from './midi/midi-bindings.js';
 import { MidiConfigUI } from './midi/midi-config-ui.js';
@@ -50,6 +51,7 @@ function boot() {
     const audio = new AudioAnalyzer();
     const renderer = new Renderer(bus, state);
     const bpmSync = new BpmSync(bus, state, renderer.clock);
+    const performanceGuard = new PerformanceGuard(bus, state, { renderer });
     const toast = new Toast(bus);
     const debugPanel = new DebugPanel(bus, state);
 
@@ -105,6 +107,7 @@ function boot() {
     // ── 4. Init UI (binds DOM elements) ──────────────────────
     renderer.initUI();
     bpmSync.initUI();
+    performanceGuard.initUI();
     debugPanel.initUI(renderer.rendererLabel);
     debugPanel.installGlobalErrorHooks();
     sceneManager.initUI();
@@ -157,7 +160,7 @@ function boot() {
     window.vjApp = {
         bus, state, audio, renderer, bpmSync, midiManager,
         layerManager, sceneManager, editorController, projectIO,
-        debugPanel, uiController
+        performanceGuard, debugPanel, uiController
     };
 
     window.render_game_to_text = () => {
@@ -193,6 +196,14 @@ function boot() {
                 toIdx: crossfade.toIdx,
                 mix: Number(crossfade.mix.toFixed(3)),
                 targetLayerIds: crossfade.layersB.map((layer) => layer.id)
+            },
+            performance: {
+                guardEnabled: state.performance.guardEnabled,
+                profile: state.performance.profile,
+                targetFps: state.performance.targetFps,
+                renderScale: Number(state.performance.renderScale.toFixed(2)),
+                freezeHiddenLayers: state.performance.freezeHiddenLayers,
+                status: state.performance.status
             }
         });
     };

--- a/src/midi/midi-actions.js
+++ b/src/midi/midi-actions.js
@@ -114,6 +114,22 @@ export const MIDI_ACTIONS = {
         continuous: false,
         target: 'none',
         defaultBehavior: 'trigger'
+    },
+    'performance.guard.toggle': {
+        label: 'Performance Guard Toggle',
+        category: 'Performance',
+        supports: ['note', 'cc'],
+        continuous: false,
+        target: 'none',
+        defaultBehavior: 'toggle'
+    },
+    'performance.profile.next': {
+        label: 'Next Performance Profile',
+        category: 'Performance',
+        supports: ['note', 'cc'],
+        continuous: false,
+        target: 'none',
+        defaultBehavior: 'trigger'
     }
 };
 

--- a/src/midi/midi-bindings.js
+++ b/src/midi/midi-bindings.js
@@ -28,6 +28,8 @@
  *   bpm:tap         {}
  *   app:blackout    { active }
  *   app:panic       {}
+ *   performance:guard-toggle {}
+ *   performance:profile-step { delta }
  *   project:autosave (when state changes via dispatch)
  */
 
@@ -291,6 +293,12 @@ export class MidiBindings {
             }
             case 'app.panic':
                 if (edgeOn) { this._bus.emit('app:panic', {}); return true; }
+                return false;
+            case 'performance.guard.toggle':
+                if (edgeOn) { this._bus.emit('performance:guard-toggle', {}); return true; }
+                return false;
+            case 'performance.profile.next':
+                if (edgeOn) { this._bus.emit('performance:profile-step', { delta: 1 }); return true; }
                 return false;
             default:
                 return false;

--- a/src/midi/midi-config-ui.js
+++ b/src/midi/midi-config-ui.js
@@ -486,7 +486,7 @@ export class MidiConfigUI {
     // ---------- Import / export ----------
 
     _exportBindings() {
-        const payload = { version: '1.1', bindings: this._state.midi.bindings };
+        const payload = { version: '1.2', bindings: this._state.midi.bindings };
         const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');

--- a/src/performance/performance-guard.js
+++ b/src/performance/performance-guard.js
@@ -1,0 +1,249 @@
+const PROFILE_ORDER = ['quality', 'balanced', 'performance'];
+
+const PROFILE_CONFIG = {
+    quality: {
+        label: 'Quality',
+        baseScale: 1,
+        thumbnailMs: 100
+    },
+    balanced: {
+        label: 'Balanced',
+        baseScale: 1,
+        thumbnailMs: 180
+    },
+    performance: {
+        label: 'Performance',
+        baseScale: 0.75,
+        thumbnailMs: 360
+    }
+};
+
+export class PerformanceGuard {
+    /**
+     * @param {import('../core/event-bus.js').EventBus} bus
+     * @param {import('../core/app-state.js').AppState} state
+     * @param {Object} deps - { renderer }
+     */
+    constructor(bus, state, deps) {
+        this._bus = bus;
+        this._state = state;
+        this._renderer = deps.renderer;
+        this._els = {};
+        this._lastMetrics = null;
+        this._lastUiUpdate = 0;
+        this._badFrames = 0;
+        this._goodFrames = 0;
+        this._lastMidiLabel = 'none';
+
+        bus.on('render:metrics', (metrics) => this._onMetrics(metrics));
+        bus.on('midi:activity', ({ signature }) => {
+            this._lastMidiLabel = signature || 'activity';
+        });
+        bus.on('scene:switched', () => this._renderStatus(true));
+        bus.on('project:loaded', () => {
+            this._normalizeState();
+            this.applySettings('project load');
+            this._syncControls();
+            this._renderStatus(true);
+        });
+        bus.on('performance:guard-toggle', () => this.setGuardEnabled(!this._state.performance.guardEnabled));
+        bus.on('performance:profile-step', ({ delta = 1 } = {}) => this.stepProfile(delta));
+    }
+
+    initUI() {
+        this._els = {
+            guardToggle: document.getElementById('performance-guard-toggle'),
+            profile: document.getElementById('performance-profile'),
+            targetFps: document.getElementById('performance-target-fps'),
+            freezeHidden: document.getElementById('performance-freeze-hidden'),
+            status: document.getElementById('performance-status'),
+            scene: document.getElementById('live-scene'),
+            layers: document.getElementById('live-layers'),
+            fps: document.getElementById('live-fps'),
+            frame: document.getElementById('live-frame-ms'),
+            scale: document.getElementById('live-render-scale'),
+            crossfade: document.getElementById('live-crossfade'),
+            midi: document.getElementById('live-midi-last'),
+            thumbnails: document.getElementById('live-thumbnail-rate')
+        };
+
+        if (this._els.guardToggle) {
+            this._els.guardToggle.onchange = (e) => this.setGuardEnabled(!!e.target.checked);
+        }
+        if (this._els.profile) {
+            this._els.profile.onchange = (e) => this.setProfile(e.target.value);
+        }
+        if (this._els.targetFps) {
+            this._els.targetFps.onchange = (e) => this.setTargetFps(Number(e.target.value));
+        }
+        if (this._els.freezeHidden) {
+            this._els.freezeHidden.onchange = (e) => this.setFreezeHidden(!!e.target.checked);
+        }
+
+        this._normalizeState();
+        this.applySettings('init');
+        this._syncControls();
+        this._renderStatus(true);
+    }
+
+    _normalizeState() {
+        const p = this._state.performance;
+        if (!PROFILE_CONFIG[p.profile]) p.profile = 'balanced';
+        if (![30, 45, 60].includes(Number(p.targetFps))) p.targetFps = 60;
+        p.adaptiveLevel = Math.max(0, Math.min(2, Number(p.adaptiveLevel) || 0));
+        p.renderScale = Math.max(0.5, Math.min(1, Number(p.renderScale) || 1));
+        p.freezeHiddenLayers = !!p.freezeHiddenLayers;
+        p.guardEnabled = p.guardEnabled !== false;
+    }
+
+    _persistPrefs() {
+        const p = this._state.performance;
+        localStorage.setItem('vj_perf_guard', p.guardEnabled ? '1' : '0');
+        localStorage.setItem('vj_perf_target_fps', String(p.targetFps));
+        localStorage.setItem('vj_perf_profile', p.profile);
+        localStorage.setItem('vj_perf_freeze_hidden', p.freezeHiddenLayers ? '1' : '0');
+    }
+
+    _syncControls() {
+        const p = this._state.performance;
+        if (this._els.guardToggle) this._els.guardToggle.checked = !!p.guardEnabled;
+        if (this._els.profile) this._els.profile.value = p.profile;
+        if (this._els.targetFps) this._els.targetFps.value = String(p.targetFps);
+        if (this._els.freezeHidden) this._els.freezeHidden.checked = !!p.freezeHiddenLayers;
+    }
+
+    setGuardEnabled(enabled) {
+        const p = this._state.performance;
+        p.guardEnabled = !!enabled;
+        p.adaptiveLevel = 0;
+        this.applySettings(enabled ? 'guard on' : 'guard off');
+        this._persistPrefs();
+        this._bus.emit('project:autosave');
+        this._bus.emit('toast', { msg: p.guardEnabled ? 'Performance Guard ON' : 'Performance Guard OFF', type: 'info' });
+        this._renderStatus(true);
+    }
+
+    setProfile(profile) {
+        const p = this._state.performance;
+        p.profile = PROFILE_CONFIG[profile] ? profile : 'balanced';
+        p.adaptiveLevel = 0;
+        this.applySettings(`profile ${p.profile}`);
+        this._persistPrefs();
+        this._bus.emit('project:autosave');
+        this._renderStatus(true);
+    }
+
+    stepProfile(delta = 1) {
+        const p = this._state.performance;
+        const idx = PROFILE_ORDER.indexOf(p.profile);
+        const cur = idx >= 0 ? idx : 1;
+        const next = (((cur + delta) % PROFILE_ORDER.length) + PROFILE_ORDER.length) % PROFILE_ORDER.length;
+        this.setProfile(PROFILE_ORDER[next]);
+        this._syncControls();
+    }
+
+    setTargetFps(fps) {
+        const p = this._state.performance;
+        p.targetFps = [30, 45, 60].includes(Number(fps)) ? Number(fps) : 60;
+        p.adaptiveLevel = 0;
+        this.applySettings(`target ${p.targetFps}`);
+        this._persistPrefs();
+        this._bus.emit('project:autosave');
+    }
+
+    setFreezeHidden(enabled) {
+        this._state.performance.freezeHiddenLayers = !!enabled;
+        this._persistPrefs();
+        this._bus.emit('project:autosave');
+        this._renderStatus(true);
+    }
+
+    applySettings(reason = 'update') {
+        const p = this._state.performance;
+        const profile = PROFILE_CONFIG[p.profile] || PROFILE_CONFIG.balanced;
+        const adaptiveScale = p.guardEnabled
+            ? Math.max(0.5, profile.baseScale * (1 - p.adaptiveLevel * 0.25))
+            : profile.baseScale;
+        const thumbnailMs = Math.round(profile.thumbnailMs * (1 + p.adaptiveLevel * 0.75));
+
+        p.renderScale = adaptiveScale;
+        p.thumbnailIntervalMs = thumbnailMs;
+        p.status = p.guardEnabled ? (p.adaptiveLevel > 0 ? 'guarding' : 'nominal') : 'manual';
+        p.lastReason = reason;
+
+        this._renderer.setRenderScale(adaptiveScale);
+        this._renderer.setThumbnailInterval(thumbnailMs);
+    }
+
+    _onMetrics(metrics) {
+        this._lastMetrics = metrics;
+        const p = this._state.performance;
+        const frameMs = Number(metrics.frameDeltaMs);
+        if (Number.isFinite(frameMs) && frameMs > 0) {
+            p.avgFrameMs = p.avgFrameMs > 0
+                ? p.avgFrameMs + (frameMs - p.avgFrameMs) * 0.08
+                : frameMs;
+        }
+
+        if (p.guardEnabled) {
+            const budget = 1000 / p.targetFps;
+            if (p.avgFrameMs > budget * 1.2) {
+                this._badFrames++;
+                this._goodFrames = 0;
+            } else if (p.avgFrameMs < budget * 0.72) {
+                this._goodFrames++;
+                this._badFrames = 0;
+            } else {
+                this._badFrames = 0;
+                this._goodFrames = 0;
+            }
+
+            if (this._badFrames >= 24 && p.adaptiveLevel < 2) {
+                p.adaptiveLevel++;
+                this._badFrames = 0;
+                this.applySettings('frame budget guard');
+                this._bus.emit('toast', { msg: `Performance Guard reduced render scale to ${(p.renderScale * 100).toFixed(0)}%`, type: 'info' });
+            } else if (this._goodFrames >= 240 && p.adaptiveLevel > 0) {
+                p.adaptiveLevel--;
+                this._goodFrames = 0;
+                this.applySettings('headroom restored');
+            }
+        }
+
+        if (!this._lastUiUpdate || metrics.nowMs - this._lastUiUpdate > 250) {
+            this._lastUiUpdate = metrics.nowMs;
+            this._renderStatus(false);
+        }
+    }
+
+    _renderStatus(force) {
+        if (!force && !this._els.status) return;
+        const p = this._state.performance;
+        const s = this._state;
+        const scene = s.sceneIdx >= 0 ? s.scenes[s.sceneIdx] : null;
+        const metrics = this._lastMetrics || {};
+        const fps = p.avgFrameMs > 0 ? 1000 / p.avgFrameMs : metrics.fps;
+
+        if (this._els.status) {
+            this._els.status.textContent = p.status.toUpperCase();
+            this._els.status.dataset.state = p.status;
+        }
+        if (this._els.scene) {
+            this._els.scene.textContent = scene ? `${s.sceneIdx + 1}. ${scene.name}` : 'none';
+        }
+        if (this._els.layers) {
+            const muted = s.layers.filter(l => l.muted).length;
+            const solo = s.soloLayerId ? ' solo' : '';
+            this._els.layers.textContent = `${s.layers.length} layer${s.layers.length === 1 ? '' : 's'}${muted ? ` / ${muted} muted` : ''}${solo}`;
+        }
+        if (this._els.fps) this._els.fps.textContent = Number.isFinite(fps) ? fps.toFixed(1) : '--';
+        if (this._els.frame) this._els.frame.textContent = `${(p.avgFrameMs || 0).toFixed(1)} ms`;
+        if (this._els.scale) this._els.scale.textContent = `${(p.renderScale * 100).toFixed(0)}%`;
+        if (this._els.crossfade) {
+            const cf = s.crossfade;
+            this._els.crossfade.textContent = cf.active ? `${(cf.mix * 100).toFixed(0)}%` : 'idle';
+        }
+        if (this._els.midi) this._els.midi.textContent = this._lastMidiLabel;
+        if (this._els.thumbnails) this._els.thumbnails.textContent = `${p.thumbnailIntervalMs} ms`;
+    }
+}

--- a/src/persistence/project-io.js
+++ b/src/persistence/project-io.js
@@ -41,7 +41,7 @@ export class ProjectIO {
     buildProjectPayload() {
         const s = this._state;
         return {
-            version: '1.1',
+            version: '1.2',
             savedAt: new Date().toISOString(),
             scenes: s.scenes,
             midi: {
@@ -51,6 +51,12 @@ export class ProjectIO {
             },
             sync: this._bpmSync.serializeSyncState(),
             crossfade: { durationBeats: s.crossfade.durationBeats },
+            performance: {
+                guardEnabled: !!s.performance.guardEnabled,
+                targetFps: s.performance.targetFps,
+                profile: s.performance.profile,
+                freezeHiddenLayers: !!s.performance.freezeHiddenLayers
+            },
             app: { blackout: !!s.blackout }
         };
     }
@@ -88,6 +94,7 @@ export class ProjectIO {
         let incomingClock = null;
         let incomingSync = null;
         let incomingCrossfade = null;
+        let incomingPerformance = null;
         let incomingApp = null;
 
         if (Array.isArray(normalizedData)) {
@@ -100,6 +107,7 @@ export class ProjectIO {
             incomingClock = midi.clock && typeof midi.clock === 'object' ? midi.clock : null;
             incomingSync = normalizedData.sync && typeof normalizedData.sync === 'object' ? normalizedData.sync : null;
             incomingCrossfade = normalizedData.crossfade && typeof normalizedData.crossfade === 'object' ? normalizedData.crossfade : null;
+            incomingPerformance = normalizedData.performance && typeof normalizedData.performance === 'object' ? normalizedData.performance : null;
             incomingApp = normalizedData.app && typeof normalizedData.app === 'object' ? normalizedData.app : null;
         }
         if (!Array.isArray(incomingScenes)) return false;
@@ -181,6 +189,15 @@ export class ProjectIO {
                 if (cfSelect) cfSelect.value = String(dur);
             }
         }
+        if (incomingPerformance) {
+            const target = Number(incomingPerformance.targetFps);
+            const profile = incomingPerformance.profile;
+            this._state.performance.guardEnabled = incomingPerformance.guardEnabled !== false;
+            this._state.performance.targetFps = [30, 45, 60].includes(target) ? target : 60;
+            this._state.performance.profile = ['quality', 'balanced', 'performance'].includes(profile) ? profile : 'balanced';
+            this._state.performance.freezeHiddenLayers = !!incomingPerformance.freezeHiddenLayers;
+            this._state.performance.adaptiveLevel = 0;
+        }
 
         this._state.sceneIdx = -1;
         this._sceneManager.renderSceneList();
@@ -201,6 +218,7 @@ export class ProjectIO {
         if (source === 'autosave') {
             this._bus.emit('toast', { msg: 'Auto-saved project restored', type: 'info' });
         }
+        this._bus.emit('project:loaded', { source });
         return true;
     }
 

--- a/src/persistence/project-migrator.js
+++ b/src/persistence/project-migrator.js
@@ -1,5 +1,5 @@
 /**
- * ProjectMigrator — Converts V0.5 project JSON to V1.0 format.
+ * ProjectMigrator — Converts legacy project JSON to the current format.
  *
  * V0.5 format:
  *   { version: "0.5-alpha", scenes, midi: { map }, sync }
@@ -8,7 +8,7 @@
  *   crossfade: { durationBeats }, audio: { bands, gains }
  */
 
-const CURRENT_VERSION = '1.1';
+const CURRENT_VERSION = '1.2';
 
 export function migrateProject(data) {
     if (!data || typeof data !== 'object') return data;
@@ -21,6 +21,7 @@ export function migrateProject(data) {
     let out = data;
     if (version === '0.5-alpha' || !data.version) out = migrateFrom05(out);
     if (out.version === '1.0') out = migrateFrom10(out);
+    if (out.version === '1.1') out = migrateFrom11(out);
     if (out.version === CURRENT_VERSION) return out;
 
     console.warn(`Unknown project version: ${out.version}, attempting load as-is`);
@@ -62,7 +63,7 @@ function migrateFrom05(data) {
 }
 
 /**
- * V1.0 → V1.1
+ * V1.0 -> V1.1
  *
  * V1.1 adds:
  *   - midi.bindings: [] (action-level bindings)
@@ -80,7 +81,29 @@ function migrateFrom10(data) {
     if (!midi.clock || typeof midi.clock !== 'object') {
         midi.clock = { enabled: false, ignoreTransport: false };
     }
-    return { ...data, version: CURRENT_VERSION, midi };
+    return { ...data, version: '1.1', midi };
+}
+
+/**
+ * V1.1 -> V1.2
+ *
+ * V1.2 adds:
+ *   - performance: Performance Guard project prefs
+ */
+function migrateFrom11(data) {
+    const performance = (data.performance && typeof data.performance === 'object')
+        ? { ...data.performance }
+        : {};
+    return {
+        ...data,
+        version: CURRENT_VERSION,
+        performance: {
+            guardEnabled: performance.guardEnabled !== false,
+            targetFps: [30, 45, 60].includes(Number(performance.targetFps)) ? Number(performance.targetFps) : 60,
+            profile: ['quality', 'balanced', 'performance'].includes(performance.profile) ? performance.profile : 'balanced',
+            freezeHiddenLayers: !!performance.freezeHiddenLayers
+        }
+    };
 }
 
 export { CURRENT_VERSION };

--- a/src/renderer/renderer.js
+++ b/src/renderer/renderer.js
@@ -36,13 +36,41 @@ export class Renderer {
 
         // Per-layer timing (for debug panel)
         this._lastLayerTimings = [];
+        this._renderWidth = 1;
+        this._renderHeight = 1;
 
         this._initThree();
+    }
+
+    _getRenderScale() {
+        const p = this._state.performance || {};
+        const raw = Number(p.renderScale);
+        return Number.isFinite(raw) ? Math.max(0.5, Math.min(1, raw)) : 1;
+    }
+
+    _computeRenderSize() {
+        const scale = this._getRenderScale();
+        return {
+            width: Math.max(2, Math.round(this._state.width * scale)),
+            height: Math.max(2, Math.round(this._state.height * scale)),
+            scale
+        };
+    }
+
+    getRenderSize() {
+        return {
+            width: this._renderWidth,
+            height: this._renderHeight,
+            scale: this._getRenderScale()
+        };
     }
 
     _initThree() {
         const s = this._state;
         const canvas = document.getElementById('main-canvas');
+        const renderSize = this._computeRenderSize();
+        this._renderWidth = renderSize.width;
+        this._renderHeight = renderSize.height;
         this.renderer = new THREE.WebGLRenderer({
             canvas,
             antialias: false,
@@ -64,8 +92,8 @@ export class Renderer {
 
         // Ping-Pong Buffers
         const pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat };
-        this.bufferA = new THREE.WebGLRenderTarget(s.width, s.height, pars);
-        this.bufferB = new THREE.WebGLRenderTarget(s.width, s.height, pars);
+        this.bufferA = new THREE.WebGLRenderTarget(this._renderWidth, this._renderHeight, pars);
+        this.bufferB = new THREE.WebGLRenderTarget(this._renderWidth, this._renderHeight, pars);
 
         // Copy material
         this.copyMat = new THREE.ShaderMaterial({
@@ -223,10 +251,7 @@ export class Renderer {
                 this._updateThumbnails();
             }
             const frameEnd2 = performance.now();
-            const frameDelta2 = deps.debugPanel._lastFrameStartMs > 0 ? (frameStart - deps.debugPanel._lastFrameStartMs) : 16.67;
-            deps.debugPanel._lastFrameStartMs = frameStart;
-            if (this._lastLayerTimings) deps.debugPanel.setLayerTimings(this._lastLayerTimings);
-            deps.debugPanel.updateMetrics(frameEnd2, frameDelta2, frameEnd2 - frameStart, frameEnd2 - renderStart);
+            this._finishFrameMetrics(deps, frameStart, renderStart, frameEnd2);
             return;
         }
 
@@ -234,9 +259,9 @@ export class Renderer {
             // Ensure crossfade buffers exist
             if (!this.crossfadeBufferA) {
                 const pars = { minFilter: THREE.LinearFilter, magFilter: THREE.LinearFilter, format: THREE.RGBAFormat };
-                this.crossfadeBufferA = new THREE.WebGLRenderTarget(s.width, s.height, pars);
-                this.crossfadeBufferB = new THREE.WebGLRenderTarget(s.width, s.height, pars);
-                this.crossfadeResultRT = new THREE.WebGLRenderTarget(s.width, s.height, pars);
+                this.crossfadeBufferA = new THREE.WebGLRenderTarget(this._renderWidth, this._renderHeight, pars);
+                this.crossfadeBufferB = new THREE.WebGLRenderTarget(this._renderWidth, this._renderHeight, pars);
+                this.crossfadeResultRT = new THREE.WebGLRenderTarget(this._renderWidth, this._renderHeight, pars);
             }
 
             // Update crossfade mix from beat position
@@ -295,10 +320,30 @@ export class Renderer {
         }
 
         const frameEnd = performance.now();
+        this._finishFrameMetrics(deps, frameStart, renderStart, frameEnd);
+    }
+
+    _finishFrameMetrics(deps, frameStart, renderStart, frameEnd) {
         const frameDelta = deps.debugPanel._lastFrameStartMs > 0 ? (frameStart - deps.debugPanel._lastFrameStartMs) : 16.67;
         deps.debugPanel._lastFrameStartMs = frameStart;
         if (this._lastLayerTimings) deps.debugPanel.setLayerTimings(this._lastLayerTimings);
         deps.debugPanel.updateMetrics(frameEnd, frameDelta, frameEnd - frameStart, frameEnd - renderStart);
+        this._bus.emit('render:metrics', {
+            nowMs: frameEnd,
+            frameDeltaMs: frameDelta,
+            cpuMs: frameEnd - frameStart,
+            renderMs: frameEnd - renderStart,
+            fps: frameDelta > 0 ? 1000 / frameDelta : 0,
+            renderScale: this._getRenderScale(),
+            renderWidth: this._renderWidth,
+            renderHeight: this._renderHeight,
+            thumbnailIntervalMs: this._thumbIntervalMs,
+            layers: this._state.layers.length,
+            crossfade: {
+                active: !!this._state.crossfade.active,
+                mix: this._state.crossfade.mix
+            }
+        });
     }
 
     /**
@@ -331,6 +376,16 @@ export class Renderer {
 
         layers.forEach((layer, i) => {
             const layerStart = performance.now();
+            const hidden = !isVisible(layer);
+            const freezeHidden = hidden && s.performance && s.performance.freezeHiddenLayers;
+            if (freezeHidden) {
+                this._lastLayerTimings.push({
+                    name: (layer.name || `Layer ${i}`) + ' (held)',
+                    ms: performance.now() - layerStart
+                });
+                return;
+            }
+
             layer.uniforms.u_time.value = time;
             layer.uniforms.u_bass.value = audio.bass;
             layer.uniforms.u_mid.value = audio.mid;
@@ -357,7 +412,7 @@ export class Renderer {
 
             // Skip composition when hidden (mute / solo), but keep per-layer render above
             // so thumbnails and feedback state stay live.
-            if (!isVisible(layer)) {
+            if (hidden) {
                 this._lastLayerTimings.push({
                     name: (layer.name || `Layer ${i}`) + ' (muted)',
                     ms: performance.now() - layerStart
@@ -433,21 +488,50 @@ export class Renderer {
         s.width = w;
         s.height = h;
         this.renderer.setSize(w, h);
-        this.bufferA.setSize(w, h);
-        this.bufferB.setSize(w, h);
+        this._resizeRenderTargets();
+        this.syncPopupSize();
+    }
+
+    setRenderScale(scale) {
+        const p = this._state.performance || {};
+        const next = Math.max(0.5, Math.min(1, Number(scale) || 1));
+        const nextWidth = Math.max(2, Math.round(this._state.width * next));
+        const nextHeight = Math.max(2, Math.round(this._state.height * next));
+        if (Math.abs((p.renderScale || 1) - next) < 0.001
+            && this._renderWidth === nextWidth
+            && this._renderHeight === nextHeight) return;
+        p.renderScale = next;
+        this._resizeRenderTargets();
+    }
+
+    setThumbnailInterval(ms) {
+        const next = Math.max(60, Math.min(1000, Math.round(Number(ms) || 180)));
+        this._thumbIntervalMs = next;
+        if (this._state.performance) {
+            this._state.performance.thumbnailIntervalMs = next;
+        }
+    }
+
+    _resizeRenderTargets() {
+        const s = this._state;
+        const renderSize = this._computeRenderSize();
+        this._renderWidth = renderSize.width;
+        this._renderHeight = renderSize.height;
+
+        this.bufferA.setSize(this._renderWidth, this._renderHeight);
+        this.bufferB.setSize(this._renderWidth, this._renderHeight);
         if (this.crossfadeBufferA) {
-            this.crossfadeBufferA.setSize(w, h);
-            this.crossfadeBufferB.setSize(w, h);
-            this.crossfadeResultRT.setSize(w, h);
+            this.crossfadeBufferA.setSize(this._renderWidth, this._renderHeight);
+            this.crossfadeBufferB.setSize(this._renderWidth, this._renderHeight);
+            this.crossfadeResultRT.setSize(this._renderWidth, this._renderHeight);
         }
         const resizeLayer = (l) => {
-            l.renderTarget.setSize(w, h);
-            if (l.fbo) l.fbo.setSize(w, h);
-            l.uniforms.u_resolution.value.set(w, h);
+            l.renderTarget.setSize(this._renderWidth, this._renderHeight);
+            if (l.fbo) l.fbo.setSize(this._renderWidth, this._renderHeight);
+            l.uniforms.u_resolution.value.set(this._renderWidth, this._renderHeight);
         };
         s.layers.forEach(resizeLayer);
         s.crossfade.layersB.forEach(resizeLayer);
-        this.syncPopupSize();
     }
 
     /** Open popup output window. */
@@ -479,7 +563,7 @@ export class Renderer {
 
     /** Create a new WebGLRenderTarget at current resolution. */
     createRenderTarget() {
-        return new THREE.WebGLRenderTarget(this._state.width, this._state.height);
+        return new THREE.WebGLRenderTarget(this._renderWidth, this._renderHeight);
     }
 
     /** Create a ShaderMaterial with the standard vertex shader. */

--- a/src/ui/ui-controller.js
+++ b/src/ui/ui-controller.js
@@ -338,6 +338,12 @@ export class UIController {
                     else this._bus.emit('app:blackout', { active: !this._state.blackout, source: 'key' });
                     return;
                 }
+                if (key === 'g') {
+                    e.preventDefault();
+                    if (e.shiftKey) this._bus.emit('performance:profile-step', { delta: 1 });
+                    else this._bus.emit('performance:guard-toggle', {});
+                    return;
+                }
             }
 
             // Escape — cancel MIDI Learn first, then close modals

--- a/styles.css
+++ b/styles.css
@@ -105,3 +105,100 @@
             color: #e9d5ff;
             border-bottom-color: #a855f7;
         }
+
+        /* ── Live Engine / Performance Guard ─────────────────── */
+        .live-engine-panel {
+            min-width: 0;
+        }
+        .performance-status-pill {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 64px;
+            height: 18px;
+            padding: 0 7px;
+            border: 1px solid #14532d;
+            border-radius: 4px;
+            background: rgba(6, 78, 59, 0.35);
+            color: #86efac;
+            font-size: 9px;
+            font-weight: 800;
+            letter-spacing: 0.08em;
+            line-height: 1;
+        }
+        .performance-status-pill[data-state="manual"] {
+            border-color: #475569;
+            background: rgba(30, 41, 59, 0.6);
+            color: #cbd5e1;
+        }
+        .performance-status-pill[data-state="guarding"] {
+            border-color: #f59e0b;
+            background: rgba(120, 53, 15, 0.5);
+            color: #fde68a;
+        }
+
+        @media (max-width: 700px) {
+            header {
+                height: auto !important;
+                min-height: 48px;
+                flex-wrap: wrap;
+                gap: 6px;
+                padding: 6px 8px !important;
+            }
+            header > div:first-child {
+                flex: 1 1 100%;
+                min-width: 0;
+                justify-content: space-between;
+            }
+            header h1 {
+                font-size: 0.95rem !important;
+                white-space: nowrap;
+            }
+            #audio-visualizer-container {
+                display: none;
+            }
+            header > div:last-child {
+                flex: 1 1 100%;
+                justify-content: flex-start;
+                gap: 6px;
+                overflow-x: auto;
+                padding-bottom: 2px;
+            }
+            header > div:last-child > * {
+                flex: 0 0 auto;
+            }
+            body > .flex-1.flex.overflow-hidden {
+                position: relative;
+            }
+            #sidebar {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                width: min(18rem, 86vw);
+                box-shadow: 0 16px 48px rgba(0, 0, 0, 0.45);
+            }
+            #sidebar.sidebar-collapsed {
+                transform: translateX(-100%);
+                width: min(18rem, 86vw) !important;
+            }
+            main {
+                min-width: 100%;
+            }
+            #layer-stack {
+                padding: 12px;
+            }
+            #layer-stack .layer-card > .grid {
+                grid-template-columns: 1fr !important;
+                gap: 12px;
+            }
+            #layer-stack .layer-card .col-span-4,
+            #layer-stack .layer-card .col-span-8 {
+                grid-column: 1 / -1;
+                border-right-width: 0 !important;
+                padding-right: 0 !important;
+            }
+            #layer-stack .layer-uniforms {
+                grid-template-columns: 1fr !important;
+            }
+        }


### PR DESCRIPTION
## Summary
- Add a Live Engine panel for scene/layer/FPS/frame/render-scale/crossfade/MIDI status
- Add Performance Guard with adaptive render-scale, profile presets, thumbnail cadence, and hidden-layer freeze
- Add Live Apply for GLSL editing plus MIDI/keyboard controls for performance guard/profile cycling
- Bump project schema to v1.2, add migration, pin WebMidi, and update esbuild to clear audit advisory

## Adopted approach
Kept the existing GLSL/WebGL pipeline and added a reversible performance/control layer. A full WebGPU rewrite was intentionally deferred because it would put the current GLSL assets, Three.js FBO compositing, Monaco live editing, and project save format at high risk.

## Verification
- npm run build
- npm audit --json (0 vulnerabilities)
- Node checks for project migration, MIDI performance actions, and Performance Guard adaptive downshift
- Playwright desktop and 390px viewport smoke checks: initial render, Live Engine visible, console errors 0

## Not verified
- Physical MIDI controller behavior after browser Web MIDI permission grant
- Long-running live performance load test
- External projector / recording workflow under production-size scenes
